### PR TITLE
Issue #97: UA指定のコンフィグを追加する

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -267,6 +267,7 @@ module app {
       no_history: "off",
       user_css: "",
       bbsmenu: "http://kita.jikkyo.org/cbm/cbm.cgi/20.p0.m0.jb.vs.op.sc.nb.bb/-all/bbsmenu.html",
+      useragent: "",
       format_2chnet: "html"
     };
 

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -229,6 +229,10 @@
             )
             %input.direct.bbsmenu(type="text" name="bbsmenu")
             %button.bbsmenu_reset(type="button") リセット
+          %br
+          %label
+            UserAgent
+            %input.direct.useragent(type="text" name="useragent")
 
       %section
         %h2 2ch.netのスレッド読み込み形式

--- a/src/view/config.scss
+++ b/src/view/config.scss
@@ -148,6 +148,10 @@ input[type="text"]:invalid {
   width: 450px;
 }
 
+.useragent {
+  width: 560px;
+}
+
 .hide {
   display: none;
 }

--- a/src/write/write.coffee
+++ b/src/write/write.coffee
@@ -32,6 +32,15 @@ app.boot "/write/write.html", ->
             ///^http://jbbs\.shitaraba\.net/bbs/write\.cgi/ ///.test(req.url)
           )
             req.requestHeaders.push(name: "Referer", value: arg.url)
+
+            # UA変更処理
+            for i in [0..req.requestHeaders.length-1]
+              if req.requestHeaders[i].name is "User-Agent"
+                ua = app.config.get("useragent")
+                if ua.replace(/\s+/g, "") is ""
+                  req.requestHeaders[i].value = ua.trim()
+                break
+
             return requestHeaders: req.requestHeaders
         return
       {


### PR DESCRIPTION
こんにちは。
UA指定について掲示板ではお世話になりました。
ご教示いただいた通り、PullRequestさせていただきます。
Issue #97のコードです。
できれば、取り込んでいただけると幸いです。

1. 仕様<br>
・ ユーザーが記事書き込み操作を実行した時、プログラムは設定画面で指定された文字列を使用し、POST電文のHTTPヘッダ-user-agentの文字列を置き換える。<br>
・ ユーザーは、設定画面に追加したラベル"UserAgent"のテキストエリアに、置き換え後の文字列を設定する。設定画面は下図を参照。<br>
・ プログラムは、"UserAgent"テキストエリアが空白の場合、POST電文のHTTPヘッダを置き換えない。<br>

[図：設定画面]
![2016-05-10](https://cloud.githubusercontent.com/assets/19171395/15121746/ed23ec58-1656-11e6-8853-cab151a4847f.png)
赤で囲った部分が今回追加したテキストエリア

以上、よろしくお願いします。