### PR TITLE
Update: タブの固定&履歴削除関連+Fix: α

### DIFF
--- a/src/core/History.coffee
+++ b/src/core/History.coffee
@@ -187,7 +187,34 @@ class app.History
             transaction.executeSql("DELETE FROM History")
           return
         ->
-          app.log("error", "app.history.clear: トランザクション中断")
+          app.log("error", "History.clear: トランザクション中断")
+          d.reject()
+          return
+        ->
+          d.resolve()
+          return
+      )
+      return
+    )
+    .promise()
+
+  ###*
+  @method clearRange
+  @param {Number} day
+  @return {Promise}
+  ###
+  @clearRange = (day) ->
+    if app.assert_arg("History.clearRange", ["number"], arguments)
+      return $.Deferred().reject().promise()
+
+    @_openDB().then((db) -> $.Deferred (d) ->
+      db.transaction(
+        (transaction) ->
+          dayUnix = Date.now()-86400000*day
+          transaction.executeSql("DELETE FROM History WHERE date < ?", [dayUnix])
+          return
+        ->
+          app.log("error", "History.clearRange: トランザクション中断")
           d.reject()
           return
         ->

--- a/src/core/History.coffee
+++ b/src/core/History.coffee
@@ -52,17 +52,30 @@ class app.History
     )
     .promise()
 
-  @remove: (url) ->
-    if app.assert_arg("History.remove", ["string"], arguments)
+  ###*
+  @method remove
+  @param {String} url
+  @param {Number} date
+  @return {Promise}
+  ###
+  @remove: (url, date) ->
+    if (
+      (date? and app.assert_arg("History.remove", ["string", "number"], arguments)) or
+      app.assert_arg("History.remove", ["string"], arguments)
+    )
       return $.Deferred().reject().promise()
 
     @_openDB().then((db) -> $.Deferred (d) ->
       db.transaction(
         (transaction) ->
-          transaction.executeSql("DELETE FROM History WHERE url = ?", [url])
+          if date?
+            console.log date
+            transaction.executeSql("DELETE FROM History WHERE (url = ? AND (date BETWEEN ? AND ?+60000-1))", [url, date, date])
+          else
+            transaction.executeSql("DELETE FROM History WHERE url = ?", [url])
           return
         ->
-          app.log("error", "app.history.remove: トランザクション中断")
+          app.log("error", "History.remove: トランザクション中断")
           d.reject()
           return
         ->

--- a/src/core/WriteHistory.coffee
+++ b/src/core/WriteHistory.coffee
@@ -63,6 +63,33 @@ class app.WriteHistory
     .promise()
 
   ###*
+  @method remove
+  @param {String} url
+  @param {Number} res
+  @return {Promise}
+  ###
+  @remove: (url, res) ->
+    if app.assert_arg("WriteHistory.remove", ["string", "number"], arguments)
+      return $.Deferred().reject().promise()
+
+    @_openDB().then((db) -> $.Deferred (d) ->
+      db.transaction(
+        (transaction) ->
+          transaction.executeSql("DELETE FROM WriteHistory WHERE url = ? AND res = ?", [url, res])
+          return
+        ->
+          app.log("error", "WriteHistory.remove: トランザクション中断")
+          d.reject()
+          return
+        ->
+          d.resolve()
+          return
+      )
+      return
+    )
+    .promise()
+
+  ###*
   @method get
   @param {Number} offset
   @param {Number} limit

--- a/src/core/WriteHistory.coffee
+++ b/src/core/WriteHistory.coffee
@@ -224,7 +224,34 @@ class app.WriteHistory
             transaction.executeSql("DELETE FROM WriteHistory")
           return
         ->
-          app.log("error", "app.WriteHistory.clear: トランザクション中断")
+          app.log("error", "WriteHistory.clear: トランザクション中断")
+          d.reject()
+          return
+        ->
+          d.resolve()
+          return
+      )
+      return
+    )
+    .promise()
+
+  ###*
+  @method clearRange
+  @param {Number} day
+  @return {Promise}
+  ###
+  @clearRange = (day) ->
+    if app.assert_arg("WriteHistory.clearRange", ["number"], arguments)
+      return $.Deferred().reject().promise()
+
+    @_openDB().then((db) -> $.Deferred (d) ->
+      db.transaction(
+        (transaction) ->
+          dayUnix = Date.now()-86400000*day
+          transaction.executeSql("DELETE FROM WriteHistory WHERE date < ?", [dayUnix])
+          return
+        ->
+          app.log("error", "WriteHistory.clearRange: トランザクション中断")
           d.reject()
           return
         ->

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -52,7 +52,7 @@ namespace UI {
               return;
             }
 
-            if (e.which === 2) {
+            if (e.which === 2 && !this.element.querySelector("li.tab_selected").classList.contains("tab_locked")) {
               tab.remove(this.getAttribute("data-tabid"));
             }
             else {
@@ -132,7 +132,8 @@ namespace UI {
           tabId: li.getAttribute("data-tabid"),
           url: li.getAttribute("data-tabsrc"),
           title: li.title,
-          selected: li.classList.contains("tab_selected")
+          selected: li.classList.contains("tab_selected"),
+          locked: li.classList.contains("tab_locked")
         });
       }
 
@@ -147,7 +148,8 @@ namespace UI {
           tabId: li.getAttribute("data-tabid"),
           url: li.getAttribute("data-tabsrc"),
           title: li.title,
-          selected: true
+          selected: true,
+          locked: li.classList.contains("tab_locked")
         };
       }
       else {
@@ -157,13 +159,14 @@ namespace UI {
 
     add (
       url: string,
-      param: {title?: string; selected?: boolean; lazy?: boolean} =
-        {title: undefined, selected: undefined, lazy: undefined}
+      param: {title?: string; selected?: boolean; locked?: boolean; lazy?: boolean} =
+        {title: undefined, selected: undefined, locked: undefined, lazy: undefined}
     ): string {
       var tabId: string;
 
       param.title = param.title === undefined ? url : param.title;
       param.selected = param.selected === undefined ? true : param.selected;
+      param.locked = param.locked === undefined ? false : param.locked;
       param.lazy = param.lazy === undefined ? false : param.lazy;
 
       tabId = Tab.genId();
@@ -193,7 +196,7 @@ namespace UI {
         })
         .appendTo(this.element.querySelector(".tab_container"));
 
-      this.update(tabId, {title: param.title, selected: param.selected});
+      this.update(tabId, {title: param.title, selected: param.selected, locked: param.locked});
 
       return tabId;
     }
@@ -204,6 +207,7 @@ namespace UI {
         url?: string;
         title?: string;
         selected?: boolean;
+        locked?: boolean;
         _internal?: boolean;
       }
     ): void {
@@ -264,6 +268,19 @@ namespace UI {
 
         $iframe.trigger("tab_selected");
       }
+      if (param.locked) {
+        $(this.element)
+          .find(`li[data-tabid=\"${tabId}\"]`)
+            .addClass("tab_locked")
+            .find("img")
+              .hide();
+      } else if (!(param.locked === void 0 || param.locked === null)) {
+        $(this.element)
+          .find(`li[data-tabid=\"${tabId}\"].tab_locked`)
+            .removeClass("tab_locked")
+            .find("img")
+              .show();
+      }
     }
 
     remove (tabId: string): void {
@@ -287,7 +304,8 @@ namespace UI {
             tab.recentClosed.push({
               tabId: this.getAttribute("data-tabid"),
               url: tabsrc,
-              title: this.title
+              title: this.title,
+              locked: this.classList.contains("tab_locked")
             });
 
             if (tab.recentClosed.length > 50) {
@@ -323,6 +341,10 @@ namespace UI {
       }
 
       return null;
+    }
+
+    isLocked (tabId: string): boolean {
+      return this.element.querySelector("li.tab_selected").classList.contains("tab_locked");
     }
   }
 }

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -344,7 +344,7 @@ namespace UI {
     }
 
     isLocked (tabId: string): boolean {
-      return this.element.querySelector("li.tab_selected").classList.contains("tab_locked");
+      return $(this.element).find(`li[data-tabid=\"${tabId}\"]`)[0].classList.contains("tab_locked");
     }
   }
 }

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -447,8 +447,10 @@ class UI.ThreadContent
             .replace(/<img src="(.*?)".*?>/ig, "$1")
             #Rock54
             .replace(/<small.*?Rock54: (Caution|Warning)\((.+?)\).*?<\/small>/ig, "<div class=\"rock54\">&#128064; Rock54: $1($2)</div>")
+            #SLIPが変わったという表示
+            .replace(/<hr>VIPQ2_EXTDAT: (.+): EXT was configured /i, "<div class=\"slipchange\">VIPQ2_EXTDAT: $1: EXT configure</div>")
             #タグ除去
-            .replace(/<(?!(?:br|hr|div class="rock54"|\/?b)>).*?(?:>|$)/ig, "")
+            .replace(/<(?!(?:br|hr|div class="(?:rock54|slipchange)"|\/?b)>).*?(?:>|$)/ig, "")
             #URLリンク
             .replace(/(h)?(ttps?:\/\/(?!img\.2ch\.net\/(?:ico|emoji)\/[\w\-_]+\.gif)(?:[a-hj-zA-HJ-Z\d_\-.!~*'();\/?:@=+$,%#]|\&(?!gt;)|[iI](?![dD]:)+)+)/g,
               '<a href="h$2" target="_blank">$1$2</a>')

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -446,7 +446,7 @@ class UI.ThreadContent
             #imgタグ変換
             .replace(/<img src="(.*?)".*?>/ig, "$1")
             #Rock54
-            .replace(/<small.*?Rock54: (Caution|Warning)\((.+?)\).*?<\/small>/ig, "<div class=\"rock54\">&#128064; Rock54: $1($2)</span>")
+            .replace(/<small.*?Rock54: (Caution|Warning)\((.+?)\).*?<\/small>/ig, "<div class=\"rock54\">&#128064; Rock54: $1($2)</div>")
             #タグ除去
             .replace(/<(?!(?:br|hr|div class="rock54"|\/?b)>).*?(?:>|$)/ig, "")
             #URLリンク

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -446,7 +446,7 @@ class UI.ThreadContent
             #imgタグ変換
             .replace(/<img src="(.*?)".*?>/ig, "$1")
             #Rock54
-            .replace(/<small.*?Rock54: (Caution|Warning)\((.+?)\).*?<\/small>/ig, "<div class=\"rock54\">&#128064; Rock54: $1($2)</div>")
+            .replace(/(?:<small.*?>&#128064;|<i>&#128064;<\/i>)<br>Rock54: (Caution|Warning)\((.+?)\) ?.*?(?:<\/small>)?/ig, "<div class=\"rock54\">&#128064; Rock54: $1($2)</div>")
             #SLIPが変わったという表示
             .replace(/<hr>VIPQ2_EXTDAT: (.+): EXT was configured /i, "<div class=\"slipchange\">VIPQ2_EXTDAT: $1: EXT configure</div>")
             #タグ除去

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -456,14 +456,14 @@ class UI.ThreadContent
               '<a href="h$2" target="_blank">$1$2</a>')
             #Beアイコン埋め込み表示
             .replace ///^(?:\s*sssp|https?)://(img\.2ch\.net/ico/[\w\-_]+\.gif)\s*<br>///, ($0, $1) =>
-              if app.url.tsld(@url) in ["2ch.net", "bbspink.com"]
-                """<img class="beicon" src="/img/dummy_1x1.png" data-src="http://#{$1}" /><br />"""
+              if app.url.tsld(@url) in ["2ch.net", "bbspink.com", "2ch.sc"]
+                """<img class="beicon" src="/img/dummy_1x1.png" data-src="http://#{$1}"><br>"""
               else
                 $0
             #エモーティコン埋め込み表示
-            .replace ///(?:\s*sssp|https?)://(img\.2ch\.net/emoji/[\w\-_]+\.gif)\s*///, ($0, $1) =>
-              if app.url.tsld(@url) in ["2ch.net", "bbspink.com"]
-                """<img class="beicon emoticon" src="/img/dummy_1x1.png" data-src="http://#{$1}" /><br />"""
+            .replace ///(?:\s*sssp|https?)://(img\.2ch\.net/emoji/[\w\-_]+\.gif)\s*///g, ($0, $1) =>
+              if app.url.tsld(@url) in ["2ch.net", "bbspink.com", "2ch.sc"]
+                """<img class="beicon emoticon" src="/img/dummy_1x1.png" data-src="http://#{$1}">"""
               else
                 $0
             #アンカーリンク

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -229,9 +229,6 @@ class UI.ThreadList
           else if $this.hasClass("del_writehistory")
             app.WriteHistory.remove(threadURL, threadWrittenRes)
             $tr.remove()
-          else if $this.hasClass("del_read_state")
-            app.read_state.remove(threadURL)
-            app.History.remove(threadURL)
 
           $this.parent().remove()
           return
@@ -258,13 +255,6 @@ class UI.ThreadList
                 $menu.find(".add_bookmark").remove()
               else
                 $menu.find(".del_bookmark").remove()
-
-              if (
-                not that._flg.unread or
-                not /^\d+$/.test(@querySelector(selector.unread).textContent) or
-                app.bookmark.get(url)?
-              )
-                $menu.find(".del_read_state").remove()
 
               $menu.one("click", "li", onClick)
 

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -92,6 +92,8 @@ class UI.ThreadList
       res: "td:nth-child(#{$table.find("th.res").index() + 1})"
       unread: "td:nth-child(#{$table.find("th.unread").index() + 1})"
       heat: "td:nth-child(#{$table.find("th.heat").index() + 1})"
+      writtenRes: "td:nth-child(#{$table.find("th.written_res").index() + 1})"
+      viewedDate: "td:nth-child(#{$table.find("th.viewed_date").index() + 1})"
 
     #ブックマーク更新時処理
     app.message.add_listener "bookmark_updated", (msg) =>
@@ -202,7 +204,7 @@ class UI.ThreadList
           return
 
     #コンテキストメニュー
-    if @_flg.bookmark or @_flg.bookmarkAddRm
+    if @_flg.bookmark or @_flg.bookmarkAddRm or @_flg.writtenRes or @_flg.viewedDate
       do ->
         onClick= ->
           $this = $(@)
@@ -211,11 +213,22 @@ class UI.ThreadList
           threadURL = $tr.attr("data-href")
           threadTitle = $tr.find(selector.title).text()
           threadRes = $tr.find(selector.res).text()
+          threadWrittenRes = parseInt($tr.find(selector.writtenRes).text())
+          date = $tr.find(selector.viewedDate).text()
+          if date? and date isnt ""
+            date_ = /(\d{4})\/(\d\d)\/(\d\d) (\d\d):(\d\d)/.exec(date)
+            threadViewedDate = new Date(date_[1], date_[2]-1, date_[3], date_[4], date_[5]).valueOf()
 
           if $this.hasClass("add_bookmark")
             app.bookmark.add(threadURL, threadTitle, threadRes)
           else if $this.hasClass("del_bookmark")
             app.bookmark.remove(threadURL)
+          else if $this.hasClass("del_history")
+            app.History.remove(threadURL, threadViewedDate)
+            $tr.remove()
+          else if $this.hasClass("del_writehistory")
+            app.WriteHistory.remove(threadURL, threadWrittenRes)
+            $tr.remove()
           else if $this.hasClass("del_read_state")
             app.read_state.remove(threadURL)
             app.History.remove(threadURL)

--- a/src/view/board.haml
+++ b/src/view/board.haml
@@ -43,4 +43,3 @@
     %ul.thread_list_contextmenu
       %li.add_bookmark ブックマークに追加
       %li.del_bookmark ブックマークを解除
-      %li.del_read_state このスレの閲覧履歴を削除

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -191,6 +191,9 @@
             %button.history_import(type="button") インポート
             %span.history_status
             %br
+            %input(type="number" class="history_date_range" min="1" value="7") 日以上の前の履歴を
+            %button.history_range_clear(type="button") 削除
+            %br
             %input.direct(type="checkbox" name="no_history") 閲覧履歴を保存しない(チェック時のみ有効)
           .writehistory
             書込履歴:
@@ -200,6 +203,9 @@
             %input(type="file" class="writehistory_file_hide hide" accept=".json")
             %button.writehistory_import(type="button") インポート
             %span.writehistory_status
+            %br
+            %input(type="number" class="writehistory_date_range" min="1" value="7") 日以上の前の履歴を
+            %button.writehistory_range_clear(type="button") 削除
             %br
             %input.direct(type="checkbox" name="no_history") 書込履歴を保存しない(チェック時のみ有効)
             %br

--- a/src/view/history.haml
+++ b/src/view/history.haml
@@ -24,3 +24,6 @@
           %li.button_history_clear 閲覧履歴を消去
     .content(tabindex="0")
     .loading_overlay Loading...
+    %template#template_thread_list_contextmenu
+      %ul.thread_list_contextmenu
+        %li.del_history この履歴を削除

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -597,6 +597,7 @@ app.main = ->
           url: tab.url
           title: tab.title
           lazy: not tab.selected
+          locked: tab.locked
           new_tab: true
         })
 
@@ -611,6 +612,7 @@ app.main = ->
       url: document.querySelector("iframe[data-tabid=\"#{tab.tabId}\"]").getAttribute("data-url")
       title: tab.title
       selected: tab.selected
+      locked: tab.locked
     localStorage.tab_state = JSON.stringify(data)
     return
 
@@ -644,6 +646,7 @@ app.main = ->
           tabId = target.add(iframe_info.src, {
             title: message.title or iframe_info.url
             selected: not (message.background or message.lazy)
+            locked: message.locked
             lazy: message.lazy
           })
         else
@@ -652,6 +655,7 @@ app.main = ->
             url: iframe_info.src
             title: message.title or iframe_info.url
             selected: true
+            locked: message.locked
           })
         $view
           .find("iframe[data-tabid=\"#{tabId}\"]")
@@ -761,6 +765,12 @@ app.main = ->
     if not getLatestRestorableTabID()
       $menu.find(".restore").remove()
 
+    if tab.isLocked(sourceTabId)
+      $menu.find(".lock").remove()
+      $menu.find(".close").remove()
+    else
+      $menu.find(".unlock").remove()
+
     if $menu.children().length is 0
       return
 
@@ -778,13 +788,20 @@ app.main = ->
             JSON.stringify(type: "request_reload")
             location.origin
           )
+      #タブを固定
+      else if $this.is(".lock")
+        tab.update(sourceTabId, locked: true)
+      #タブの固定を解除
+      else if $this.is(".unlock")
+        tab.update(sourceTabId, locked: false)
       #タブを閉じる
       else if $this.is(".close")
         tab.remove(sourceTabId)
       #タブを全て閉じる
       else if $this.is(".close_all")
         $source.siblings().andBack().each ->
-          tab.remove($(@).attr("data-tabid"))
+          tabid = $(@).attr("data-tabid")
+          tab.remove(tabid) unless tab.isLock(tabid)
           return
       #他のタブを全て閉じる
       else if $this.is(".close_all_other")

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -799,7 +799,7 @@ app.main = ->
         tab.remove(sourceTabId)
       #タブを全て閉じる
       else if $this.is(".close_all")
-        $source.siblings().andBack().each ->
+        $source.siblings().addBack().each ->
           tabid = $(@).attr("data-tabid")
           tab.remove(tabid) unless tab.isLocked(tabid)
           return

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -801,7 +801,7 @@ app.main = ->
       else if $this.is(".close_all")
         $source.siblings().andBack().each ->
           tabid = $(@).attr("data-tabid")
-          tab.remove(tabid) unless tab.isLock(tabid)
+          tab.remove(tabid) unless tab.isLocked(tabid)
           return
       #他のタブを全て閉じる
       else if $this.is(".close_all_other")

--- a/src/view/index.haml
+++ b/src/view/index.haml
@@ -85,6 +85,8 @@
       %ul.tab_contextmenu
         %li.restore 閉じたタブを開く
         %li.reload 再読み込み
+        %li.lock タブを固定
+        %li.unlock タブの固定を解除
         %li.close タブを閉じる
         %li.close_all 全てのタブを閉じる
         %li.close_all_other 他のタブを全て閉じる

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -207,9 +207,7 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
       $article = $(@).parent()
       $menu = $(
         $("#template_res_menu").prop("content").querySelector(".res_menu")
-      ).clone()
-      # 何故かjQuery 2.1.0で例外が発生するので.hideを使わない
-      $menu.css("display": "none").appendTo($article)
+      ).clone().hide().appendTo($article)
 
       app.defer ->
         if getSelection().toString().length is 0

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -197,7 +197,7 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
       if (
         e.type is "click" and
         app.config.get("popup_trigger") is "click" and
-        $(e.target).is(".id.link, .id.freq, .anchor_id, .slip.link, .slip.freq, .trip.link, .trip.freq")
+        $(e.target).is(".id.link, .id.freq, .anchor_id, .slip.link, .slip.freq, .trip.link, .trip.freq, .rep.link, .rep.freq")
       )
         return
 

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -235,6 +235,11 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
       unless app.url.tsld(view_url) in ["2ch.net", "bbspink.com", "shitaraba.net"]
         $menu.find(".res_to_this, .res_to_this2").remove()
 
+      if $article.hasClass("written")
+        $menu.find(".add_writehistory").remove()
+      else
+        $menu.find(".del_writehistory").remove()
+
       unless $article.is(".popup > article")
         $menu.find(".jump_to_this").remove()
 
@@ -287,6 +292,11 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
         date2 = new Date(date1[1], date1[2]-1, date1[3], date1[4], date1[5], date1[6]).valueOf()
         app.WriteHistory.add(view_url, resnum, document.title, name, mail, name, mail, message, date2)
         $res.addClass("written")
+
+      else if $this.hasClass("del_writehistory")
+        resnum = parseInt($res.find(".num").text())
+        app.WriteHistory.remove(view_url, resnum)
+        $res.removeClass("written")
 
       else if $this.hasClass("toggle_aa_mode")
         $res.toggleClass("aa")

--- a/src/view/thread.haml
+++ b/src/view/thread.haml
@@ -67,5 +67,6 @@
         %li.res_to_this 返信
         %li.res_to_this2 引用して返信
         %li.add_writehistory 書込履歴に追加
+        %li.del_writehistory 書込履歴から削除
         %li.toggle_aa_mode
         %li.res_permalink Chromeで開く

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -379,8 +379,8 @@ header {
   $thread-footer-button-background-color,
   $thread-footer-button-color,
   $thread-res-info-color,
-  $rock54-background-color,
-  $rock54-border-color
+  $thread-caution-background-color,
+  $thread-caution-border-color
 ) {
   & {
     background-color: $background-color;
@@ -446,10 +446,10 @@ header {
     }
   }
 
-  .rock54 {
-    border: 1px solid $rock54-border-color;
+  .rock54, .slipchange {
+    border: 1px solid $thread-caution-border-color;
     border-radius: 3px;
-    background: $rock54-background-color;
+    background: $thread-caution-background-color;
   }
 
   .content[data-res_search_hit_count="0"]:after {
@@ -492,8 +492,8 @@ header {
     $thread-footer-button-background-color: #eee,
     $thread-footer-button-color: #222,
     $thread-res-info-color: #666,
-    $rock54-background-color: #eee,
-    $rock54-border-color: #ccc
+    $thread-caution-background-color: #eee,
+    $thread-caution-border-color: #ccc
   );
 }
 
@@ -519,8 +519,8 @@ header {
     $thread-footer-button-background-color: #333,
     $thread-footer-button-color: #ddd,
     $thread-res-info-color: silver,
-    $rock54-background-color: #444,
-    $rock54-border-color: #666
+    $thread-caution-background-color: #444,
+    $thread-caution-border-color: #666
   );
 }
 

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -450,6 +450,7 @@ header {
     border: 1px solid $thread-caution-border-color;
     border-radius: 3px;
     background: $thread-caution-background-color;
+    margin-top: 15px;
   }
 
   .content[data-res_search_hit_count="0"]:after {

--- a/src/view/writehistory.haml
+++ b/src/view/writehistory.haml
@@ -24,3 +24,6 @@
           %li.button_history_clear 書込履歴を消去
     .content(tabindex="0")
     .loading_overlay Loading...
+    %template#template_thread_list_contextmenu
+      %ul.thread_list_contextmenu
+        %li.del_writehistory この履歴を削除


### PR DESCRIPTION
Update: タグを固定できるように
Update: SLIPが適応された表示のデザインを変更
Update: 閲覧書込履歴一覧から履歴を削除できるように ref #142
Update: スレから書込履歴を削除できるように close #142
Update: 範囲を指定して履歴を削除できるように close #121
Fix: 返信をクリックしてメニューが表示されないように
Fix: Rock54の判定をより正確に
Fix: Beアイコン/エモーティコンを2ch.scでも表示するように
Fix: 閲覧履歴削除ボタンを削除 close #113
Fix: すべてのタブを閉じるが実行できないのを修正