### PR TITLE
Fix: ImageReplaceDat関連&jQueryをslimバージョンに

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -350,5 +350,5 @@ end
 
 task :jquery do
   mkdir_p "debug/lib/jquery"
-  cp "node_modules/jquery/dist/jquery.min.js", "debug/lib/jquery/jquery.min.js"
+  cp "node_modules/jquery/dist/jquery.slim.min.js", "debug/lib/jquery/jquery.slim.min.js"
 end

--- a/src/common.scss
+++ b/src/common.scss
@@ -64,6 +64,12 @@ $z-index-notification: 9;
     transition: opacity 250ms ease-in-out;
   }
 
+  .slide {
+    height: 0;
+    overflow: hidden;
+    transition: height 250ms ease-in-out;
+  }
+
   .hidden {
     display: none;
   }

--- a/src/core/ImageReplaceDat.coffee
+++ b/src/core/ImageReplaceDat.coffee
@@ -145,7 +145,7 @@ class app.ImageReplaceDat
       continue if d.baseUrl is "invalid://invalid"
       continue if !d.baseUrlReg.test(string)
       if d.replaceUrl is ""
-        d.reject()
+        def.reject(a, "No parsing")
         break
 
       doing = true

--- a/src/core/ImageReplaceDat.coffee
+++ b/src/core/ImageReplaceDat.coffee
@@ -98,8 +98,8 @@ class app.ImageReplaceDat
     if string isnt ""
       datStrSplit = string.split("\n")
       for d in datStrSplit
-        if ["//",";", "'"].some((ele) -> return d.startsWith(ele))
-          continue
+        continue if d is ""
+        continue if ["//",";", "'"].some((ele) -> return d.startsWith(ele))
         r = d.split("\t")
         if r[0]?
           obj =

--- a/src/core/ImageReplaceDat.coffee
+++ b/src/core/ImageReplaceDat.coffee
@@ -145,7 +145,7 @@ class app.ImageReplaceDat
       continue if d.baseUrl is "invalid://invalid"
       continue if !d.baseUrlReg.test(string)
       if d.replaceUrl is ""
-        def.reject(a, "No parsing")
+        def.resolve(a, string, "No parsing")
         break
 
       doing = true
@@ -164,7 +164,7 @@ class app.ImageReplaceDat
           def.resolve(a, res)
           return
         ).fail(->
-          def.reject(a, "Fail getExtract")
+          def.resolve(a, string, "Fail getExtract")
           return
         )
       else
@@ -175,10 +175,11 @@ class app.ImageReplaceDat
             def.resolve(a, res)
             return
           ).fail(->
-            def.reject(a, "Fail getCookie")
+            def.resolve(a, string, "Fail getCookie")
             return
           )
         else
           def.resolve(a, res)
-    def.reject(a, "Fail noBaseUrlReg") unless doing
+      break
+    def.resolve(a, string, "Fail noBaseUrlReg") unless doing
     return def.promise()

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -379,14 +379,6 @@ class app.Thread
           mail: regRes[1] or ""
           message: regRes[4]
           other: regRes[3]
-      else
-        continue if true or line is ""
-        numberOfBroken++
-        thread.res.push
-          name: "</b>データ破損<b>"
-          mail: ""
-          message: "データが破損しています"
-          other: ""
 
     if thread.res.length > 0 and thread.res.length > numberOfBroken
       thread
@@ -442,28 +434,41 @@ class app.Thread
   @_parseMachi = (text) ->
     thread = {res: []}
     resCount = 0
+    numberOfBroken = 0
 
     for line in text.split("\n")
       continue if line is ""
       # res_num, name, mail, other, message, thread_title
       sp = line.split("<>")
-      while ++resCount isnt +sp[0]
+      if sp.length >= 5
+        while ++resCount isnt +sp[0]
+          thread.res.push
+            name: "あぼーん"
+            mail: "あぼーん"
+            message: "あぼーん"
+            other: "あぼーん"
+
+        if resCount is 1
+          thread.title = app.util.decode_char_reference(sp[5])
+
         thread.res.push
-          name: "あぼーん"
-          mail: "あぼーん"
-          message: "あぼーん"
-          other: "あぼーん"
+          name: sp[1]
+          mail: sp[2]
+          message: sp[4]
+          other: sp[3]
+      else
+        continue if line is ""
+        numberOfBroken++
+        thread.res.push
+          name: "</b>データ破損<b>"
+          mail: ""
+          message: "データが破損しています"
+          other: ""
 
-      if resCount is 1
-        thread.title = app.util.decode_char_reference(sp[5])
-
-      thread.res.push
-        name: sp[1]
-        mail: sp[2]
-        message: sp[4]
-        other: sp[3]
-
-    if thread.res.length > 0 then thread else null
+    if thread.res.length > 0 and thread.res.length > numberOfBroken
+      thread
+    else
+      null
 
   ###*
   @method _parseJbbs
@@ -475,25 +480,39 @@ class app.Thread
   @_parseJbbs = (text) ->
     thread = {res: []}
     resCount = 0
+    numberOfBroken = 0
 
     for line in text.split("\n")
       continue if line is ""
       # res_num, name, mail, date, message, thread_title, id
       sp = line.split("<>")
-      while ++resCount isnt +sp[0]
+      if sp.length >= 6
+        while ++resCount isnt +sp[0]
+          thread.res.push
+            name: "あぼーん"
+            mail: "あぼーん"
+            message: "あぼーん"
+            other: "あぼーん"
+
+        if resCount is 1
+          thread.title = app.util.decode_char_reference(sp[5])
+
         thread.res.push
-          name: "あぼーん"
-          mail: "あぼーん"
-          message: "あぼーん"
-          other: "あぼーん"
+          name: sp[1]
+          mail: sp[2]
+          message: sp[4]
+          other: sp[3] + if sp[6] then " ID:#{sp[6]}" else ""
 
-      if resCount is 1
-        thread.title = app.util.decode_char_reference(sp[5])
+      else
+        continue if line is ""
+        numberOfBroken++
+        thread.res.push
+          name: "</b>データ破損<b>"
+          mail: ""
+          message: "データが破損しています"
+          other: ""
 
-      thread.res.push
-        name: sp[1]
-        mail: sp[2]
-        message: sp[4]
-        other: sp[3] + if sp[6] then " ID:#{sp[6]}" else ""
-
-    if thread.res.length > 0 then thread else null
+    if thread.res.length > 0 and thread.res.length > numberOfBroken
+      thread
+    else
+      null

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -263,8 +263,8 @@ app.util.concurrent = (array, func) ->
   deferArray = []
   for a in array
     deferArray.push(func(a))
-  $.when.apply(null, deferArray).always(->
-    d.resolve(Array.from(arguments))
+  $.when(deferArray...).done( (res...) ->
+    d.resolve(res)
     return
   )
   return d.promise()

--- a/src/ui/Accordion.ts
+++ b/src/ui/Accordion.ts
@@ -91,7 +91,6 @@ namespace UI {
       $(header)
         .removeClass("accordion_open")
         .next()
-          .finish()
           .removeAttr("style");
         setTimeout( () => {
           $(header).next()

--- a/src/ui/Accordion.ts
+++ b/src/ui/Accordion.ts
@@ -1,4 +1,5 @@
 ///<reference path="../../typings/globals/jquery/index.d.ts" />
+///<reference path="../app.ts" />
 
 namespace UI {
   "use strict";
@@ -17,8 +18,7 @@ namespace UI {
 
       this.$element.addClass("accordion");
 
-      this.$element.find(".accordion_open").removeClass("accordion_open");
-      this.$element.find(":header + :not(:header)").addClass("hidden");
+      this.$element.find(".accordion_open").removeClass(".accordion_open");
 
       this.$element.on("click", "> :header", function () {
         if (this.classList.contains("accordion_open")) {
@@ -30,18 +30,42 @@ namespace UI {
       });
     }
 
+    private getOriginHeight($ele: JQuery): number {
+      var $e = $ele.clone();
+      var width = $ele[0].clientWidth;
+      $e.css({
+        height: "auto",
+        width: width,
+        position: "absolute",
+        visibility: "hidden",
+        display: "block"
+      });
+      $("body").append($e);
+      var height = $e[0].clientHeight;
+      $e.remove();
+      return height;
+    }
+
     update (): void {
       this.$element
         .find(".accordion_open + *")
-          .finish()
           .removeClass("hidden")
         .end()
         .find(":header:not(.accordion_open) + *")
-          .finish()
-          .addClass("hidden");
+          .removeAttr("style");
+        setTimeout( () => {
+          this.$element
+            .find(".accordion_open + *")
+              .css("height", this.getOriginHeight(this.$element.find(".accordion_open + *")));
+        }, 0);
+        setTimeout( () => {
+          this.$element
+            .find(":header:not(.accordion_open) + *")
+              .addClass("hidden");
+        }, 250);
     }
 
-    open (header: HTMLElement, duration: number = 250): void {
+    open (header: HTMLElement): void {
       var accordion: Accordion;
 
       accordion = this;
@@ -49,21 +73,30 @@ namespace UI {
       $(header)
         .addClass("accordion_open")
         .next()
-          .finish()
-          .slideDown(duration)
+          .removeClass("hidden")
         .end()
         .siblings(".accordion_open")
           .each(function () {
-            accordion.close(this, duration);
+            accordion.close(this);
           });
+        setTimeout( () => {
+          $(header)
+            .addClass("accordion_open")
+            .next()
+              .css("height", this.getOriginHeight($(header).next()));
+        }, 0);
     }
 
-    close (header: HTMLElement, duration: number = 250): void {
+    close (header: HTMLElement): void {
       $(header)
         .removeClass("accordion_open")
         .next()
           .finish()
-          .slideUp(duration);
+          .removeAttr("style");
+        setTimeout( () => {
+          $(header).next()
+            .addClass("hidden");
+        }, 250);
     }
   }
 }

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -569,11 +569,11 @@ class UI.ThreadContent
           null
 
         app.util.concurrent(@container.querySelectorAll(".message > a:not(.thumbnail):not(.has_thumbnail)"), (a) ->
-          return app.ImageReplaceDat.do(a, a.href).done( (a, res) ->
-            addThumbnail(a, res.text, res.referrer, res.cookie)
+          return app.ImageReplaceDat.do(a, a.href).done( (a, res, err) ->
+            addThumbnail(a, res.text, res.referrer, res.cookie) unless err?
             return
           )
-        ).done(->
+        ).done( ->
           d.resolve()
           return
         )

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -79,7 +79,20 @@ class UI.ThreadContent
 
     if target
       if animate
-        @_$container.animate(scrollTop: target.offsetTop + offset)
+        do =>
+          to = target.offsetTop + offset
+          now = @container.scrollTop
+          change = (to - now)/15
+          min = Math.min(to-change, to+change)
+          max = Math.max(to-change, to+change)
+          animateInterval = setInterval( =>
+            if min <= @container.scrollTop <= max
+              @container.scrollTop = to
+              clearInterval(animateInterval)
+            else
+              @container.scrollTop += change
+            return
+          , 20)
       else
         @container.scrollTop = target.offsetTop + offset
     return

--- a/src/ui/popup.coffee
+++ b/src/ui/popup.coffee
@@ -74,24 +74,29 @@ do ($ = jQuery) ->
         top: mouse_y
         bottom: document.body.offsetHeight - mouse_y
 
+      css = {}
       #通常はカーソル左か右のスペースを用いるが、そのどちらもが狭い場合は上下に配置する
       if Math.max(space.left, space.right) > 400
         #例え右より左が広くても、右に十分なスペースが有れば右に配置
         if space.right > 350
-          $popup.css("left", "#{space.left + margin}px")
-          $popup.css("max-width", document.body.offsetWidth - space.left - margin * 2)
+          css =
+            left: "#{space.left + margin}px"
+            "max-width": document.body.offsetWidth - space.left - margin * 2
         else
-          $popup.css("right", "#{space.right + margin}px")
-          $popup.css("max-width", document.body.offsetWidth - space.right - margin * 2)
-        $popup.css("top", "#{Math.min(space.top, document.body.offsetHeight - $popup.outerHeight()) - margin}px")
+          css =
+            right: "#{space.right + margin}px"
+            "max-width": document.body.offsetWidth - space.right - margin * 2
+        css.top = "#{Math.min(space.top, document.body.offsetHeight - $popup.outerHeight()) - margin}px"
       else
         #例え上より下が広くても、上に十分なスペースが有れば上に配置
         if space.top > Math.min(350, space.bottom)
-          $popup.css("bottom", space.bottom + margin)
+          css.bottom = space.bottom + margin
         else
-          $popup.css("top", document.body.offsetHeight - space.bottom + margin)
-        $popup.css("left", margin)
-        $popup.css("max-width", document.body.offsetWidth - margin * 2)
+          css.top = document.body.offsetHeight - space.bottom + margin
+        css =
+          left: margin
+          "max-width": document.body.offsetWidth - margin * 2
+      $popup.css(css)
       return
 
     $(source)

--- a/src/ui/table_search.coffee
+++ b/src/ui/table_search.coffee
@@ -26,5 +26,5 @@ do ($ = jQuery) ->
     else if method is "clear"
       $table.removeClass("table_search")
 
-    $table.show()
+    $table.removeClass("hidden")
     @

--- a/src/view/board.haml
+++ b/src/view/board.haml
@@ -6,7 +6,7 @@
     %title board
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="board.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/ui.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")

--- a/src/view/bookmark.haml
+++ b/src/view/bookmark.haml
@@ -6,7 +6,7 @@
     %title ブックマーク
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="bookmark.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/ui.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")

--- a/src/view/bookmark_source_selector.haml
+++ b/src/view/bookmark_source_selector.haml
@@ -5,7 +5,7 @@
     %meta(name="referrer" content="never")
     %title ブックマークフォルダの設定
     %link(rel="stylesheet" href="bookmark_source_selector.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")
     %script(src="bookmark_source_selector.js?v=#{MANIFEST["version"]}")

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -259,7 +259,7 @@ app.boot "/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
           $status
             .addClass("done")
             .text("#{count}件 インポート完了")
-          $clear_button.show()
+          $clear_button.removeClass("hidden")
           return
         .fail ->
           $status

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -6,7 +6,7 @@
     %title 設定
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="config.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/ui.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -105,7 +105,10 @@
             %input.direct(name="auto_load_move" type="radio" value="newest") 最終レス
 
       %section
-        %h2 サムネイル表示
+        %h2
+          サムネイル表示(
+          %a(href="https://github.com/readcrx-2/read.crx-2/wiki/ImageViewURLReplace.dat%E3%81%AE%E4%BB%95%E6%A7%98" target="_blank") 詳細
+          )
         %div
           %label
             %textarea.direct(name="image_replace_dat" rows="6" cols="80")

--- a/src/view/history.haml
+++ b/src/view/history.haml
@@ -6,7 +6,7 @@
     %title 閲覧履歴
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="history.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/ui.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")

--- a/src/view/index.haml
+++ b/src/view/index.haml
@@ -7,7 +7,7 @@
     %link(rel="shortcut icon" href="/img/favicon.ico")
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="index.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/ui.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="/app_core.js?v=#{MANIFEST["version"]}")

--- a/src/view/inputurl.haml
+++ b/src/view/inputurl.haml
@@ -6,7 +6,7 @@
     %title URLを指定して開く
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="inputurl.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")
     %script(src="inputurl.js?v=#{MANIFEST["version"]}")

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -210,7 +210,7 @@ class app.view.IframeView extends app.view.View
     @$element
       .find(".command")
         .data("lastActiveElement", document.activeElement)
-        .show()
+        .removeClass("hidden")
         .focus()
     return
 
@@ -569,7 +569,7 @@ class app.view.TabContentView extends app.view.PaneContentView
 
     #メニューの表示/非表示制御
     @$element.find(".button_tool").on "click", ->
-      if $(@).find("ul").toggle().is(":visible")
+      if $(@).find("ul").toggleClass("hidden").hasClass("hidden")
         app.defer ->
           that.$element.one "click contextmenu", (e) ->
             if not $(e.target).is(".button_tool")

--- a/src/view/search.haml
+++ b/src/view/search.haml
@@ -6,7 +6,7 @@
     %title search
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="search.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/ui.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")

--- a/src/view/sidemenu.coffee
+++ b/src/view/sidemenu.coffee
@@ -90,6 +90,9 @@ app.boot "/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
             frag.appendChild(h3)
 
             ul = document.createElement("ul")
+            cl = ul.classList
+            cl.add("slide")
+            cl.add("hidden")
             for board in category.board
               ul.appendChild(board_to_li(board))
             frag.appendChild(ul)

--- a/src/view/sidemenu.haml
+++ b/src/view/sidemenu.haml
@@ -16,7 +16,7 @@
       %input(type="text" name="q" placeholder="スレッド検索")
       %input(type="submit" value="")
     %h3 read.crx
-    %ul
+    %ul.slide.hidden
       %li
         %a(class="open_in_rcrx" data-href="bookmark" title="ブックマーク") ブックマーク
       %li

--- a/src/view/sidemenu.haml
+++ b/src/view/sidemenu.haml
@@ -6,7 +6,7 @@
     %title sidemenu
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="sidemenu.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/ui.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")

--- a/src/view/sidemenu.scss
+++ b/src/view/sidemenu.scss
@@ -25,7 +25,7 @@ h3 {
 
 ul {
   margin: 0;
-  padding: 5px 0;
+  padding: 0;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);
   list-style-type: none;
 }

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -247,7 +247,7 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
         $menu.find(".jump_to_this").remove()
 
       app.defer ->
-        $menu.show()
+        $menu.removeClass("hidden")
         $.contextmenu($menu, e.clientX, e.clientY)
         return
       return
@@ -281,7 +281,7 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
 
         app.defer ->
           unless getSelection().toString().length is 0
-            $menu.show()
+            $menu.removeClass("hidden")
             $.contextmenu($menu, e.clientX, e.clientY)
         return
       return
@@ -618,7 +618,7 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
               .end()
               .find(".hit_count")
                 .text(hit_count + "hit")
-                .show()
+                .removeClass("hidden")
 
             if scrollTop is $content.scrollTop()
               $content.triggerHandler("scroll")

--- a/src/view/thread.haml
+++ b/src/view/thread.haml
@@ -6,7 +6,7 @@
     %title
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="thread.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/ui.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")

--- a/src/view/writehistory.haml
+++ b/src/view/writehistory.haml
@@ -6,7 +6,7 @@
     %title 書込履歴
     %link(rel="stylesheet" href="/ui.css?v=#{MANIFEST["version"]}")
     %link(rel="stylesheet" href="writehistory.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/ui.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="module.js?v=#{MANIFEST["version"]}")

--- a/src/write/submit_thread.haml
+++ b/src/write/submit_thread.haml
@@ -5,7 +5,7 @@
     %meta(name="referrer" content="never")
     %title 新規スレッド作成
     %link(rel="stylesheet" href="/write/submit_thread.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="/write/submit_thread.js?v=#{MANIFEST["version"]}")
   %body.view_write

--- a/src/write/write.haml
+++ b/src/write/write.haml
@@ -5,7 +5,7 @@
     %meta(name="referrer" content="never")
     %title
     %link(rel="stylesheet" href="/write/write.css?v=#{MANIFEST["version"]}")
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="/write/write.js?v=#{MANIFEST["version"]}")
   %body.view_write

--- a/src/zombie.haml
+++ b/src/zombie.haml
@@ -5,7 +5,7 @@
     %meta(name="referrer" content="never")
     %meta(http-equiv="X-Frame-Options" content="SAMEORIGIN")
     %title read.crx 2
-    %script(src="/lib/jquery/jquery.min.js?v=#{MANIFEST["version"]}")
+    %script(src="/lib/jquery/jquery.slim.min.js?v=#{MANIFEST["version"]}")
     %script(src="/app.js?v=#{MANIFEST["version"]}")
     %script(src="/zombie.js?v=#{MANIFEST["version"]}")
   %body


### PR DESCRIPTION
Fix: ImageReplaceDatのreplaceUrlが空のときに処理が止まるのを修正
Fix: ImageReplaceDatで空白行を無視できていなかったのを修正
Fix: ImageReplaceDatがどこかでこけると全部こけるのを修正
Fix: 設定のサムネイル表示にwikiへのリンクを追加
Fix: jQueryをslimバージョンに

※jQueryのanimation/show・hide/fadeIn・Out/slideUp・Down/ajax/非推奨は利用できなくなりました
(
 * animation関連は元々利用箇所が少なかったので書いたほうが短い
 * show・hideはclass操作のほうが動作が軽い
 * fadeIn・Out/slideUp・Downはcssのほうが動作が軽い
 * ajaxはそもそもapp.HTTPモジュールで代用可(リファクタリング予定)
 * 非推奨のものは3.0アップデート時に既に削除済み

)