### PR TITLE
Update: 「グロ」「死ね」レスのある画像にぼかしをかける

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -257,6 +257,8 @@ namespace app {
       auto_load_second: "0",
       auto_load_all: "off",
       auto_load_move: "off",
+      image_blur: "off",
+      image_blur_length: "4",
       aa_font: "aa",
       popup_trigger: "click",
       ngwords: "",

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -58,6 +58,17 @@ app.boot "/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
         app.config.set(@name, val)
         return
 
+  $view
+    .find("input.direct[type=\"range\"]")
+      .each ->
+        @value = app.config.get(@name) or "0"
+        $view.find(".#{@name}_text").text(@value)
+        null
+      .on "input", ->
+        $view.find(".#{@name}_text").text(@value)
+        app.config.set(@name, @value)
+        return
+
   #バージョン情報表示
   $view.find(".version_text")
     .text("#{app.manifest.name} v#{app.manifest.version} + #{navigator.userAgent}")

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -119,6 +119,15 @@
           %input(type="file" class="dat_file_hide hidden" accept=".dat")
           %button.dat_import_button(type="button") インポート
           %span.dat_import_status
+          %br
+          %label
+            %input.direct(type="checkbox" name="image_blur")
+            「グロ」「死ね」を含むレスがある場合、画像にぼかしをかける
+          %label
+            ぼかし具合:
+            %input.direct(type="range" name="image_blur_length" min="1" max="9")
+            %span.image_blur_length_text
+            px
 
       %section
         %h2 アスキーアート表示

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -246,6 +246,21 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
       unless $article.is(".popup > article")
         $menu.find(".jump_to_this").remove()
 
+      # 画像にぼかしをかける/画像のぼかしを解除する
+      unless $article.hasClass("has_image")
+        $menu.find(".set_image_blur").remove()
+        $menu.find(".reset_image_blur").remove()
+      else
+        bflg = false
+        for res in $article.find(".thumbnail")
+          continue unless res.classList.contains("image_blur")
+          bflg = true
+          break
+        if bflg
+          $menu.find(".set_image_blur").remove()
+        else
+          $menu.find(".reset_image_blur").remove()
+
       app.defer ->
         $menu.removeClass("hidden")
         $.contextmenu($menu, e.clientX, e.clientY)
@@ -276,6 +291,8 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
           ".add_writehistory,"+
           ".del_writehistory,"+
           ".toggle_aa_mode,"+
+          ".set_image_blur,"+
+          ".reset_image_blur,"+
           ".res_permalink"
         ).remove()
 
@@ -357,6 +374,16 @@ app.boot "/view/thread.html", ["board_title_solver"], (BoardTitleSolver) ->
 
       else if $this.hasClass("res_permalink")
         open(app.safe_href(view_url + $res.find(".num").text()))
+
+      # 画像をぼかす
+      else if $this.hasClass("set_image_blur")
+        dftval = app.config.get("image_blur_default")
+        for thumb in $res.find(".thumbnail")
+          $view.data("threadContent").setImageBlur(thumb, true)
+      # 画像のぼかしを解除する
+      else if $this.hasClass("reset_image_blur")
+        for thumb in $res.find(".thumbnail")
+          $view.data("threadContent").setImageBlur(thumb, false)
 
       $this.parent().remove()
       return

--- a/src/view/thread.haml
+++ b/src/view/thread.haml
@@ -72,4 +72,6 @@
         %li.add_writehistory 書込履歴に追加
         %li.del_writehistory 書込履歴から削除
         %li.toggle_aa_mode
+        %li.set_image_blur 画像にぼかしをかける
+        %li.reset_image_blur 画像のぼかしを解除する
         %li.res_permalink Chromeで開く


### PR DESCRIPTION
サムネイルにぼかしをかける機能を追加してみました。
app.ImageReplaceDatの呼び出しと終了確認の方法については、今後公表する可能性のある別機能との
兼ね合いより、変更をしました。
レビューをお願いします。