### PR TITLE
Fix: ぼかしの設定を取り消してもぼかしがかかってしまう件を修正

### DIFF
--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -546,7 +546,7 @@ class UI.ThreadContent
         for res in @harmImgIndex
           ele = @container.children[res - 1]
           ele.addClass("has_blur_word")
-          if ele.hasClass("has_image")
+          if ele.hasClass("has_image") and app.config.get("image_blur") is "on"
             for thumb in ele.querySelectorAll(".thumbnail:not(.image_blur)")
               @setImageBlur(thumb, true)
         return


### PR DESCRIPTION
690 名無しさん [sage] 2016/09/16(金) 09:02:46ID:q6c3H9Gc(1)
＞・H.Izawaさんの「グロ」「死ね」という返信レスがあるサムネをぼかすのを取り込み

チェック入れてないのにぼかしが入ってしまいます

read.crx 2 v1.9.1 + Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36


上記の件、修正しておきましたのでよろしくお願いします。