### PR TITLE
Fix: (popup)表示位置設定の誤りを修正(マウスの座標かぶり)

### DIFF
--- a/src/ui/popup.coffee
+++ b/src/ui/popup.coffee
@@ -85,7 +85,7 @@ do ($ = jQuery) ->
             maxWidth: "#{document.body.offsetWidth - space.left - margin * 2}px"
         else
           css =
-            right: "#{space.right - margin}px"
+            right: "#{space.right + margin}px"
             maxWidth: "#{document.body.offsetWidth - space.right - margin * 2}px"
         cursorTop = Math.max(space.top, viewTop + margin * 2)
         if viewHeight > $popup.outerHeight()


### PR DESCRIPTION
ポップアップがマウスの左側に表示される際に、マウスの座標とポップアップがかぶっていたのを修正しました。
よろしくお願いします。