### PR TITLE
画像のロードにまつわる修正

### DIFF
--- a/src/ui/LazyLoad.ts
+++ b/src/ui/LazyLoad.ts
@@ -52,7 +52,9 @@ namespace UI {
       this.pause = true;
     }
 
+    // 検索による表示位置の変更に対応するため、テーブルをクリアしてから再開する
     private onSearchFinish(): void {
+      this.imgPlaceTable.clear();
       this.pause = false;
     }
 

--- a/src/ui/LazyLoad.ts
+++ b/src/ui/LazyLoad.ts
@@ -11,12 +11,17 @@ namespace UI {
     private imgs: HTMLImageElement[] = [];
     private imgPlaceTable = new Map<HTMLImageElement, number>();
     private updateInterval: number = null;
+    private pause: boolean = false;
 
     constructor (container: HTMLElement) {
       this.container = container;
 
       $(this.container).on("scroll", this.onScroll.bind(this));
       $(this.container).on("resize", this.onResize.bind(this));
+      $(this.container).on("scrollstart", this.onScrollStart.bind(this));
+      $(this.container).on("scrollfinish", this.onScrollFinish.bind(this));
+      $(this.container).on("searchstart", this.onSearchStart.bind(this));
+      $(this.container).on("searchfinish", this.onSearchFinish.bind(this));
       this.scan();
     }
 
@@ -31,6 +36,24 @@ namespace UI {
     public immediateLoad (img: HTMLImageElement): void {
       if (img.getAttribute("data-src") === null) return;
       this.load(img);
+    }
+
+    // スクロール中に無駄な画像ロードが発生するのを防止する
+    private onScrollStart(): void {
+      this.pause = true;
+    }
+
+    private onScrollFinish(): void {
+      this.pause = false;
+    }
+
+    // 検索中に無駄な画像ロードが発生するのを防止する
+    private onSearchStart(): void {
+      this.pause = true;
+    }
+
+    private onSearchFinish(): void {
+      this.pause = false;
     }
 
     private load (img: HTMLImageElement): void {
@@ -92,6 +115,7 @@ namespace UI {
       var scrollTop: number, clientHeight: number;
       scrollTop = this.container.scrollTop;
       clientHeight = this.container.clientHeight;
+      if (this.pause === true) return;
 
       this.imgs = this.imgs.filter((img: HTMLImageElement) => {
         var top: number, current: HTMLElement;

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -87,6 +87,8 @@ class UI.ThreadContent
     if target
       if animate
         do =>
+          @_$container.trigger("scrollstart")
+
           to = target.offsetTop + offset
           change = (to - @container.scrollTop)/15
           min = Math.min(to-change, to+change)
@@ -95,10 +97,12 @@ class UI.ThreadContent
             before = @container.scrollTop
             if min <= @container.scrollTop <= max
               @container.scrollTop = to
+              @_$container.trigger("scrollfinish")
               return
             else
               @container.scrollTop += change
             if @container.scrollTop is before
+              @_$container.trigger("scrollfinish")
               return
             requestAnimationFrame(_scrollInterval)
             return

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -492,17 +492,13 @@ class UI.ThreadContent
 
       @container.insertAdjacentHTML("BeforeEnd", html)
 
-      fragment = document.createDocumentFragment()
-      for child in @container.children
-        fragment.appendChild(child.cloneNode(true))
-
       numbersReg = /(?:\(\d+\))?$/
       #idカウント, .freq/.link更新
       do =>
         for id, index of @idIndex
           idCount = index.length
           for resNum in index
-            elm = fragment.children[resNum - 1].getElementsByClassName("id")[0]
+            elm = @container.children[resNum - 1].getElementsByClassName("id")[0]
             elmFirst = elm.firstChild
             elmFirst.textContent = elmFirst.textContent.replace(numbersReg, "(#{idCount})")
             if idCount >= 5
@@ -517,7 +513,7 @@ class UI.ThreadContent
         for slip, index of @slipIndex
           slipCount = index.length
           for resNum in index
-            elm = fragment.children[resNum - 1].getElementsByClassName("slip")[0]
+            elm = @container.children[resNum - 1].getElementsByClassName("slip")[0]
             elmFirst = elm.firstChild
             elmFirst.textContent = elmFirst.textContent.replace(numbersReg, "(#{slipCount})")
             if slipCount >= 5
@@ -532,7 +528,7 @@ class UI.ThreadContent
         for trip, index of @tripIndex
           tripCount = index.length
           for resNum in index
-            elm = fragment.children[resNum - 1].getElementsByClassName("trip")[0]
+            elm = @container.children[resNum - 1].getElementsByClassName("trip")[0]
             elmFirst = elm.firstChild
             elmFirst.textContent = elmFirst.textContent.replace(numbersReg, "(#{tripCount})")
             if tripCount >= 5
@@ -545,7 +541,7 @@ class UI.ThreadContent
       #harmImg更新
       do =>
         for res in @harmImgIndex
-          elm = fragment.children[res - 1]
+          elm = @container.children[res - 1]
           continue unless elm
           elm.classList.add("has_blur_word")
           if elm.classList.contains("has_image") and app.config.get("image_blur") is "on"
@@ -556,7 +552,7 @@ class UI.ThreadContent
       #参照関係再構築
       do =>
         for resKey, index of @repIndex
-          res = fragment.children[resKey - 1]
+          res = @container.children[resKey - 1]
           if res
             resCount = index.length
             if elm = res.getElementsByClassName("rep")[0]
@@ -575,11 +571,11 @@ class UI.ThreadContent
             #連鎖NG
             if app.config.get("chain_ng") is "on" and res.classList.contains("ng")
               for r in index
-                fragment.children[r - 1].classList.add("ng")
+                @container.children[r - 1].classList.add("ng")
             #自分に対してのレス
             if res.classList.contains("written")
               for r in index
-                fragment.children[r - 1].classList.add("to_written")
+                @container.children[r - 1].classList.add("to_written")
         return
 
       #サムネイル追加処理
@@ -629,14 +625,12 @@ class UI.ThreadContent
               break
           null
 
-        app.util.concurrent(fragment.querySelectorAll(".message > a:not(.thumbnail):not(.has_thumbnail)"), (a) ->
+        app.util.concurrent(@container.querySelectorAll(".message > a:not(.thumbnail):not(.has_thumbnail)"), (a) ->
           return app.ImageReplaceDat.do(a, a.href).done( (a, res, err) ->
             addThumbnail(a, res.text, res.referrer, res.cookie) unless err?
             return
           )
         ).always(=>
-          @container.textContent = null
-          @container.appendChild(fragment)
           d.resolve()
           return
         )

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -615,6 +615,7 @@ app.boot "/view/thread.html", ->
           return
         .on "input", ->
           return if _isComposing
+          $content.triggerHandler("searchstart")
           if @value isnt ""
             if typeof search_stored_scrollTop isnt "number"
               search_stored_scrollTop = $content.scrollTop()
@@ -660,6 +661,8 @@ app.boot "/view/thread.html", ->
             if typeof search_stored_scrollTop is "number"
               $content.scrollTop(search_stored_scrollTop)
               search_stored_scrollTop = null
+
+          $content.triggerHandler("searchfinish")
           return
 
         .on "keyup", (e) ->


### PR DESCRIPTION
後続の機能追加に関連する修正群です。
コンフリクト防止のため、こちらがmergeされた後に機能追加分をプルリクする予定です。

Fix: 画像の大量ロードを防止するため、LazyLoadを一時停止する
　　スクロール時とスレッド内での検索時に無駄に画像がロードされることを防止します。

Fix: 画像がローディング表示のままになることがある現象の修正
　　ThreadContent内でのfragmentを使用した処理により、画像がローディング表示の
　　ままになってしまうことと、後の機能追加によるイベントハンドラの消失を防止します。

Fix: スレッド内検索で表示されない画像がある現象の修正
　　LazyLoad高速化対策としての座標テーブルをクリアして、表示条件の変化に対応します。
