### PR TITLE
機能追加(2/4): マウスオーバーによる画像の拡大機能を追加

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -261,6 +261,8 @@ namespace app {
       ["image_blur_word", ".*[^ァ-ヺ^ー]グロ([^ァ-ヺ^ー].*|$)|.*死ね.*"],
       ["image_width", "150"],
       ["image_height", "100"],
+      ["hover_zoom_image", "off"],
+      ["zoom_ratio_image", "200"],
       ["image_height_fix", "on"],
       ["delay_scroll_time", "600"],
       ["aa_font", "aa"],

--- a/src/common.scss
+++ b/src/common.scss
@@ -8,6 +8,7 @@ $z-index-dialog: 6;
 $z-index-modal: 7;
 $z-index-modalhelp: 8;
 $z-index-notification: 9;
+$z-index-thumnail-zoom: 20;
 
 $color-pending: #7F7F7F;
 $color-loading: #AC7239;

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -162,6 +162,17 @@
       %section
         %h2 画像オプション
         %div
+          %label
+            マウスを重ねた時に拡大表示
+            %br
+            %label
+              %input.direct(type="checkbox" name="hover_zoom_image") サムネイル
+            %label
+              拡大率:
+              %input.direct(type="range" name="zoom_ratio_image" min="100" max="500" step="5")
+              %span.zoom_ratio_image_text
+              \%
+          %br
           %dl
             %dt 位置合わせの制御方法
             %dd 拡張機能を使用して画像のサイズを指定する場合、スレッドを開いた時の位置合わせの方法を指定します。

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -81,6 +81,10 @@ app.boot "/view/thread.html", ->
       $view.data("lazyload").immediateLoad(@)
       return
     app.defer ->
+      # マウスオーバーによるズームの設定
+      $popup.find("img.image").each ->
+        app.view_thread._setupHoverZoom(@)
+      # popupの表示
       popupView.show($popup[0], e.clientX, e.clientY, that)
       return
 
@@ -784,6 +788,8 @@ app.boot "/view/thread.html", ->
     # Lazyloadを実行させるためにスクロールを発火
     if app.config.get("image_height_fix") is "off"
       $content.triggerHandler("scroll")
+    # マウスオーバーによるズームの設定
+    app.view_thread._setupHoverZoom(@)
     return
 
   # 逆スクロール時の位置合わせ
@@ -793,6 +799,8 @@ app.boot "/view/thread.html", ->
       imgHeight = @offsetHeight
       imgHeight -= 50   # loading.webp
       content.scrollTop += imgHeight
+    # マウスオーバーによるズームの設定
+    app.view_thread._setupHoverZoom(@)
     return
 
   #パンくずリスト表示
@@ -972,3 +980,18 @@ app.view_thread._read_state_manager = ($view) ->
       return if $view.hasClass("loading")
       scan_and_save()
       return
+
+# マウスオーバーによるズームの設定
+app.view_thread._setupHoverZoom = (img) ->
+  zoomFlg = false
+  if app.config.get("hover_zoom_image") is "on" and img.tagName is "IMG"
+    zoomRatio = app.config.get("zoom_ratio_image") + "%"
+    zoomFlg = true
+  if zoomFlg
+    $(img).hover ->
+      $(img.closest(".thumbnail")).addClass("zoom")
+      $(img).css("zoom", zoomRatio)
+    , ->
+      $(img.closest(".thumbnail")).removeClass("zoom")
+      $(img).css("zoom", "normal")
+  return

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -144,7 +144,7 @@ header {
   > a {
     $a-padding: 3px;
     position: relative;
-    display: block;
+    display: inline-block;
     background-color: white;
     padding: $a-padding;
     box-shadow: 0 1px 3px 0px rgba(black, 0.4);
@@ -171,6 +171,9 @@ header {
       background: hsl(0, 0%, 97.5%);
       border-radius: 2px;
     }
+  }
+  &.zoom {
+     z-index: $z-index-thumnail-zoom;
   }
 }
 


### PR DESCRIPTION
以前サポート掲示板で公表されていたユーザーCSSを参考にして、プログラムとして機能を追加したものになります。
ユーザーCSSを元にしているため、z-indexの値についてこのままで良いのか疑問が残ります。ご意見を頂けると助かります。

補足
・サムネイルとビデオは表示サイズを別々に指定可能にしているため、拡大率についても別々に指定可能になります。
・CSSにてaタグのdisplayをinline-blockに変更してあるのは、拡大時に他の文字や画像に被らないようにするためで、a, audio, videoではbackground-color以外は共通の設定になります。

以上、よろしくお願いします。