### PR TITLE
機能追加(4/4): 短縮URLの展開機能を追加

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -275,6 +275,8 @@ namespace app {
       ["zoom_ratio_video", "200"],
       ["image_height_fix", "on"],
       ["delay_scroll_time", "600"],
+      ["expand_short_url", "none"],
+      ["expand_short_url_timeout", "3000"],
       ["aa_font", "aa"],
       ["popup_trigger", "click"],
       ["ngwords", ""],

--- a/src/core/HTTP.ts
+++ b/src/core/HTTP.ts
@@ -1,3 +1,5 @@
+///<reference path="../global.d.ts" />
+
 namespace app.HTTP {
   "use strict";
 
@@ -70,7 +72,7 @@ namespace app.HTTP {
 
         resonseHeaders = Request.parseHTTPHeader(xhr.getAllResponseHeaders());
 
-        callback(new Response(xhr.status, resonseHeaders, xhr.responseText));
+        callback(new Response(xhr.status, resonseHeaders, xhr.responseText, xhr.responseURL));
       });
 
       xhr.addEventListener("timeout", () => {
@@ -115,7 +117,8 @@ namespace app.HTTP {
     constructor (
       public status:number,
       public headers:{[index:string]:string;} = {},
-      public body:string = null
+      public body:string = null,
+      public responseURL: string = null
     ) {
     }
   }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,3 +3,7 @@
 namespace UI {
   declare var Animate:any;
 }
+
+interface XMLHttpRequest {
+  responseURL: string;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,8 @@
     "notifications",
     "webRequest",
     "webRequestBlocking",
-    "http://*/"
+    "http://*/",
+    "https://*/"
   ],
   "app" : {
     "launch" : {

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -243,6 +243,23 @@
             %input.direct(type="number" name="delay_scroll_time" min="0" max="5000")ms
 
       %section
+        %h2 短縮URLの展開
+        %div
+          %label
+            %input.direct(name="expand_short_url" type="radio" value="none" checked)
+            何もしない
+          %label
+            %input.direct(name="expand_short_url" type="radio" value="inline")
+            本文内に表示する
+          %label
+            %input.direct(name="expand_short_url" type="radio" value="popup")
+            マウスを重ねた時にポップアップする
+          %br
+          %label
+            タイムアウト:
+            %input.direct(type="number" name="expand_short_url_timeout" min="0")ms
+
+      %section
         %h2 アスキーアート表示
         %div
           %label

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -603,6 +603,25 @@ app.boot "/view/thread.html", ->
       app.view_thread._controlVideoCursor(@, e.type)
       return
 
+    # 展開済みURLのポップアップ
+    .on "mouseenter", ".has_expandedURL", (e) ->
+      return if app.config.get("expand_short_url") isnt "popup"
+      popup_helper this, e, =>
+        targetUrl = this.href
+
+        frag = document.createDocumentFragment()
+        sib = this
+        while true
+          sib = sib.nextSibling
+          if sib?.classList?.contains("expandedURL") and
+             sib?.getAttribute("short-url") is targetUrl
+            frag.appendChild(sib.cloneNode(true))
+            break
+
+        frag.querySelector(".expandedURL").classList.remove("hide_data")
+        $popup = $("<div>").append(frag)
+      return
+
   #クイックジャンプパネル
   do ->
     jump_hoge =

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -182,6 +182,35 @@ header {
   }
 }
 
+.expandedURL {
+  position: relative;
+  display: inline-block;
+  margin: 5px 10px;
+
+  > a {
+    font-style: italic;
+  }
+  &::before {
+    margin-right: 10px;
+    content: "(" attr(short-url) ") →";
+  }
+  > .thumbnail {
+    margin-left: 30px;
+  }
+  &.expand_error::after {
+    content: "展開できませんでした。";
+  }
+
+  .popup & {
+    display: block;
+    padding: 5px;
+  }
+}
+
+.hide_data {
+  display: none;
+}
+
 .popup {
   position: fixed;
   z-index: $z-index-popup;


### PR DESCRIPTION
短縮URLの展開機能の追加です。
対象となるサイトは、t.coを除きヘッダのリクエストでLocation:が返ってくるものを対象にしています。
($ curl -I -i URL (linuxの場合) にて確認)
ただし、youtu.beのようなサムネイルの取得で対応可能と思われるものは含まれていません。

よろしくお願いします。