### PR TITLE
Fix: 1ページ目の画像チェックで遅延スクロールが実行されない

### DIFF
--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -152,6 +152,15 @@ class UI.ThreadContent
       tmpResNum++
       tmpTarget = @container.children[tmpResNum - 1]
 
+    # 遅延スクロールの設定
+    if loadFlag or @_timeoutID isnt 0
+      clearTimeout(@_timeoutID) if @_timeoutID isnt 0
+      delayScrollTime = parseInt(app.config.get("delay_scroll_time"))
+      @_timeoutID = setTimeout( =>
+        @_timeoutID = 0
+        @_reScrollTo()
+      , delayScrollTime)
+
     return loadFlag
 
   ###*
@@ -184,13 +193,7 @@ class UI.ThreadContent
 
       # 遅延スクロールの設定
       if loadFlag or @_timeoutID isnt 0
-        clearTimeout(@_timeoutID) if @_timeoutID isnt 0
         @container.scrollTop = target.offsetTop + offset
-        delayScrollTime = parseInt(app.config.get("delay_scroll_time"))
-        @_timeoutID = setTimeout( =>
-          @_timeoutID = 0
-          @_reScrollTo()
-        , delayScrollTime)
         return
       return if rerun and @container.scrollTop is target.offsetTop + offset
 


### PR DESCRIPTION
画像の存在チェック処理とスクロール処理を分離した際の修正漏れにより、1ページ目のみに画像が存在していた場合に遅延スクロールが実行されていませんでした。
お手数おかけしますが、よろしくお願いします。