### PR TITLE
Update: コンテキストメニューの拡張

### DIFF
--- a/src/core/ContextMenus.coffee
+++ b/src/core/ContextMenus.coffee
@@ -1,0 +1,68 @@
+###*
+@namespace app
+@class contextMenus
+@static
+###
+class app.contextMenus
+# chrome.contextMenusの呼び出しレベルを統一するための代理クラス
+# (Chrome 53 対策)
+
+  ###*
+  @method createAll
+  ###
+  @createAll: ->
+    id = chrome.runtime.id
+    viewThread = "chrome-extension://#{id}/view/thread.html*"
+
+    @create(
+      id: "add_selection_to_ngwords",
+      title: "選択範囲をNG指定",
+      contexts: ["selection"],
+      documentUrlPatterns: [viewThread]
+    )
+    @create(
+      id: "add_link_to_ngwords",
+      title: "リンクアドレスをNG指定",
+      contexts: ["link"],
+      enabled: false,
+      documentUrlPatterns: [viewThread]
+    )
+    @create(
+      id: "add_media_to_ngwords",
+      title: "メディアのアドレスをNG指定",
+      contexts: ["image", "video", "audio"],
+      documentUrlPatterns: [viewThread]
+    )
+    return
+
+  ###*
+  @method create
+  @parm {Object} obj
+  @return {Number|String} id
+  ###
+  @create: (obj)->
+    return chrome.contextMenus.create(obj)
+
+  ###*
+  @method update
+  @parm {Number|String} id
+  @parm {Object} obj
+  ###
+  @update: (id, obj)->
+    chrome.contextMenus.update(id, obj)
+    return
+
+  ###*
+  @method remove
+  @parm {Number|String} id
+  ###
+  @remove: (id)->
+    chrome.contextMenus.remove(id)
+    return
+
+  ###*
+  @method removeAll
+  ###
+  @removeAll: ->
+    chrome.contextMenus.removeAll()
+    return

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,6 +18,7 @@
     "notifications",
     "webRequest",
     "webRequestBlocking",
+    "contextMenus",
     "http://*/",
     "https://*/"
   ],

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -615,6 +615,9 @@ app.main = ->
       app.message.send("open", url: "bookmark")
     return
 
+  # コンテキストメニューの作成
+  app.contextMenus.createAll()
+
   #終了時にタブの状態を保存する
   window.addEventListener "unload", ->
     data = for tab in tabA.getAll().concat(tabB.getAll())
@@ -623,6 +626,8 @@ app.main = ->
       selected: tab.selected
       locked: tab.locked
     localStorage.tab_state = JSON.stringify(data)
+    #コンテキストメニューの削除
+    app.contextMenus.removeAll()
     return
 
   #openメッセージ受信部

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -9,6 +9,7 @@ do ->
       "bookmark"
       "bookmarkEntryList"
       "config"
+      "contextMenus"
       "ImageReplaceDat"
       "module"
       "Ninja"

--- a/src/view/thread.haml
+++ b/src/view/thread.haml
@@ -60,7 +60,6 @@
     %template#template_res_menu
       %menu.res_menu
         %li.copy_selection 選択範囲をコピー
-        %li.add_selection_to_ngwords 選択範囲をNG指定
         %li.search_selection 選択範囲を検索
         %li.copy_id ID/IPをコピー
         %li.add_id_to_ngwords ID/IPをNG指定


### PR DESCRIPTION
コンテキストメニューを拡張し、選択範囲/リンクのアドレス/画像(動画・音声)のアドレスのNG指定ができるようにしてみました。
chrome 53よりview/thread.coffeeからchrome.contextMenus.updateを実行することができなくなったため、core/ContextMenus.coffeeを新規に用意し、chrome.contextMenusのメソッドを静的メンバとして間接的に呼び出す形にしましたが、恥ずかしながら、何故こうすれば動くのかは正直なところわかっておりません。
このような不確かなものを組み込むことはできないと言うことであればPRを取り下げます。

よろしくお願いします。