### PR TITLE
ここから新着の線が表示されない場合がある #232 の修正

### DIFF
--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -900,6 +900,7 @@ app.view_thread._draw = ($view, force_update, beforeAdd) ->
   deferred = $.Deferred()
 
   $view.addClass("loading")
+  $view.css("cursor", "wait")
   $reload_button = $view.find(".button_reload")
   $reload_button.addClass("disabled")
   content = $view.find(".content")[0]
@@ -939,6 +940,7 @@ app.view_thread._draw = ($view, force_update, beforeAdd) ->
         threadGetDeferred = fn(thread, not promiseThreadGetState)
         .always ->
           $view.removeClass("loading")
+          $view.css("cursor", "auto")
           setTimeout((-> $reload_button.removeClass("disabled")), 1000 * 5)
           if threadGetDeferred.state() is "resolved" then deferred.resolve() else deferred.reject()
           return

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -74,14 +74,14 @@ article {
   content: "しおり";
 }
 
-.read:not(:last-child):after {
-  @include view_thread_res_info;
-  content: "ここから未読";
-}
-
 .received:not(:last-child):after {
   @include view_thread_res_info;
   content: "ここから新着";
+}
+
+.read:not(:last-child):after {
+  @include view_thread_res_info;
+  content: "ここから未読";
 }
 
 header {


### PR DESCRIPTION
1. 「ここから新着」と「ここから未読」の表示優先順位を入れ替える。
2. スレッドのロード中はマウス・ポインタを変更することによりメッセージを表示させる。

上記2つの修正を行いました。

2.については、マウス・ポインタが通過することによりメッセージが表示されることから、コンテナに対してなんからのイベントまたは通知を送れば変化があるのではないかと思い試したものですが、理由はわかりませんが表示されるようになりました。
どっちが副作用なのかわからない修正ですが、あっても困らないかなと・・・