### PR TITLE
Fix: リロードで既読位置がずれる refs #201

### DIFF
--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -896,6 +896,8 @@ app.boot "/view/thread.html", ->
 
   return
 
+readStateAttached = false
+
 app.view_thread._draw = ($view, force_update, beforeAdd) ->
   deferred = $.Deferred()
 
@@ -927,6 +929,7 @@ app.view_thread._draw = ($view, force_update, beforeAdd) ->
   thread = new app.Thread($view.attr("data-url"))
   threadGetDeferred = null
   promiseThreadGet = thread.get(force_update)
+  readStateAttached = false
   promiseThreadGet
     .progress ->
       threadGetDeferred = fn(thread, false)


### PR DESCRIPTION
d5b6c12139079146007c65b87d2e19728da1abd2 のテスト中にも発生したため調べたところ #201 の原因の1つは、ThreadContentのgetReadが誤った値を戻すことまでは判明していますが、再現性が低いためその原因まではわかっていません。

d5b6c12139079146007c65b87d2e19728da1abd2 の適用後にも同じ現象が起こることがわかったので修正をしました。こちらは、勢いの速いスレでリロードを実行すると簡単に発生します。