### PR TITLE
Fix: BBSPINKで表示がおかしくなることがある close #257

### DIFF
--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -234,9 +234,17 @@ class app.Thread
           if @tsld in ["2ch.net", "bbspink.com"] and noChangeFlg is false
             if readcgisixFlg
               if @tsld is "bbspink.com"
-                before = response.body.indexOf("</div><section class=\"thread\">")+30
-                after = response.body.indexOf("</dd></dl></section><div>")+10
-                place = cache.data.indexOf("</dd></dl></section><div>")+10
+                before = response.body.indexOf("</h1><dl class=\"post\"")+5
+                after = response.body.indexOf("</dd></dl></section><div>")
+                if after isnt -1
+                  after += 10
+                else
+                  after = response.body.indexOf("</dd></dl></section>")+10
+                place = cache.data.indexOf("</dd></dl></section><div>")
+                if place isnt -1
+                  place +=10
+                else
+                  place = cache.data.indexOf("</dd></dl></section>")
               else
                 before = response.body.indexOf("<div class=\"thread\">")+20
                 after = response.body.indexOf("</div></div></div>")+12


### PR DESCRIPTION
`before`の位置が間違っていた点と、`after`と`place`については2パターンあることがわかったので修正しました。