### PR TITLE
Fix: httpsリンクへの対応 close #263

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -219,6 +219,7 @@ namespace :img do
     "debug/img/close_16x16.webp",
     "debug/img/dummy_1x1.webp",
     "debug/img/loading.webp",
+    "debug/img/lock_12x12_3a5.webp",
 
     "debug/img/arrow_19x19_333_r90.webp",
     "debug/img/arrow_19x19_333_r-90.webp",
@@ -228,6 +229,8 @@ namespace :img do
     "debug/img/reload_19x19_333.webp",
     "debug/img/pencil_19x19_333.webp",
     "debug/img/menu_19x19_333.webp",
+    "debug/img/lock_19x19_182.webp",
+    "debug/img/unlock_19x19_333.webp",
 
     "debug/img/arrow_19x19_ddd_r90.webp",
     "debug/img/arrow_19x19_ddd_r-90.webp",
@@ -236,7 +239,9 @@ namespace :img do
     "debug/img/star_19x19_f93.webp",
     "debug/img/reload_19x19_ddd.webp",
     "debug/img/pencil_19x19_ddd.webp",
-    "debug/img/menu_19x19_ddd.webp"
+    "debug/img/menu_19x19_ddd.webp",
+    "debug/img/lock_19x19_3a5.webp",
+    "debug/img/unlock_19x19_ddd.webp"
   ]
 
   directory "debug/img"

--- a/src/app.ts
+++ b/src/app.ts
@@ -240,6 +240,7 @@ namespace app {
       ["theme_id", "default"],
       ["always_new_tab", "on"],
       ["button_change_netsc_newtab", "off"],
+      ["button_change_scheme_newtab", "off"],
       ["open_all_unread_lazy", "on"],
       ["dblclick_reload", "on"],
       ["auto_load_second", "0"],

--- a/src/common.scss
+++ b/src/common.scss
@@ -14,6 +14,7 @@ $color-pending: #7F7F7F;
 $color-loading: #AC7239;
 $color-success: #339933;
 $color-error: #BF3F3F;
+$color-https: #109020;
 
 @mixin common {
   button, input, select, textarea {
@@ -312,6 +313,7 @@ $color-error: #BF3F3F;
       $icon-color: "333",
       $active-icon-color: "007fff",
       $search-icon-color: "777",
+      $https-icon-color: "182",
       $color: #111,
       $tool-menu-hover-background: hsl(210, 50%, 95%)
     );
@@ -329,6 +331,7 @@ $color-error: #BF3F3F;
       $icon-color: "ddd",
       $active-icon-color: "f93",
       $search-icon-color: "aaa",
+      $https-icon-color: "3a5",
       $color: #eee,
       $tool-menu-hover-background: hsl(30, 100%, 40%)
     );
@@ -352,6 +355,7 @@ $color-error: #BF3F3F;
   $icon-color,
   $active-icon-color,
   $search-icon-color,
+  $https-icon-color,
   $color,
   $tool-menu-hover-background
 ) {
@@ -383,6 +387,12 @@ $color-error: #BF3F3F;
       }
       &.button_write {
         background-image: url(/img/pencil_19x19_#{$icon-color}.webp);
+      }
+      &.button_scheme {
+        background-image: url(/img/unlock_19x19_#{$icon-color}.webp);
+        &.https {
+          background-image: url(/img/lock_19x19_#{$https-icon-color}.webp);
+        }
       }
       &.button_tool {
         background-image: url(/img/menu_19x19_#{$icon-color}.webp);

--- a/src/core/BBSMenu.coffee
+++ b/src/core/BBSMenu.coffee
@@ -24,7 +24,7 @@ class app.BBSMenu
   ###
   @parse: (html) ->
     reg_category = ///<b>(.+?)</b>(?:.*[\r\n]+<a\s.*?>.+?</a>)+///gi
-    reg_board = ///<a\shref=(http://(?!info\.2ch\.net/|headline\.bbspink\.com)
+    reg_board = ///<a\shref=(https?://(?!info\.2ch\.net/|headline\.bbspink\.com)
       \w+\.(?:2ch\.net|machi\.to|open2ch\.net|2ch\.sc|bbspink\.com)/\w+/)(?:\s.*?)?>(.+?)</a>///gi
 
     menu = []

--- a/src/core/Board.coffee
+++ b/src/core/Board.coffee
@@ -167,18 +167,18 @@ class app.Board
   @return {Object | null} xhr_info
   ###
   @_get_xhr_info: (board_url) ->
-    tmp = ///^http://((?:\w+\.)?(\w+\.\w+))/(\w+)/(?:(\d+)/)?$///.exec(board_url)
+    tmp = ///^(https?)://((?:\w+\.)?(\w+\.\w+))/(\w+)/(?:(\d+)/)?$///.exec(board_url)
     unless tmp
       return null
-    switch tmp[2]
+    switch tmp[3]
       when "machi.to"
-        path: "http://#{tmp[1]}/bbs/offlaw.cgi/#{tmp[3]}/"
+        path: "#{tmp[1]}://#{tmp[2]}/bbs/offlaw.cgi/#{tmp[4]}/"
         charset: "Shift_JIS"
       when "livedoor.jp", "shitaraba.net"
-        path: "http://jbbs.shitaraba.net/#{tmp[3]}/#{tmp[4]}/subject.txt"
+        path: "#{tmp[1]}://jbbs.shitaraba.net/#{tmp[4]}/#{tmp[5]}/subject.txt"
         charset: "EUC-JP"
       else
-        path: "http://#{tmp[1]}/#{tmp[3]}/subject.txt"
+        path: "#{tmp[1]}://#{tmp[2]}/#{tmp[4]}/subject.txt"
         charset: "Shift_JIS"
 
   ###*
@@ -189,20 +189,20 @@ class app.Board
   @return {Array | null} board
   ###
   @parse: (url, text) ->
-    tmp = /^http:\/\/((?:\w+\.)?(\w+\.\w+))\/(\w+)\/(\w+)?/.exec(url)
-    switch tmp[2]
+    tmp = /^(https?):\/\/((?:\w+\.)?(\w+\.\w+))\/(\w+)\/(\w+)?/.exec(url)
+    switch tmp[3]
       when "machi.to"
         bbs_type = "machi"
         reg = /^\d+<>(\d+)<>(.+)\((\d+)\)$/gm
-        base_url = "http://#{tmp[1]}/bbs/read.cgi/#{tmp[3]}/"
+        base_url = "#{tmp[1]}://#{tmp[2]}/bbs/read.cgi/#{tmp[4]}/"
       when "shitaraba.net"
         bbs_type = "jbbs"
         reg = /^(\d+)\.cgi,(.+)\((\d+)\)$/gm
-        base_url = "http://jbbs.shitaraba.net/bbs/read.cgi/#{tmp[3]}/#{tmp[4]}/"
+        base_url = "#{tmp[1]}://jbbs.shitaraba.net/bbs/read.cgi/#{tmp[4]}/#{tmp[5]}/"
       else
         bbs_type = "2ch"
         reg = /^(\d+)\.dat<>(.+) \((\d+)\)$/gm
-        base_url = "http://#{tmp[1]}/test/read.cgi/#{tmp[3]}/"
+        base_url = "#{tmp[1]}://#{tmp[2]}/test/read.cgi/#{tmp[4]}/"
 
     board = []
     while (reg_res = reg.exec(text))

--- a/src/core/BoardTitleSolver.coffee
+++ b/src/core/BoardTitleSolver.coffee
@@ -43,8 +43,12 @@ class app.BoardTitleSolver
   ###
   @searchFromBBSMenu: (url) ->
     @getBBSMenu().then((bbsmenu) => $.Deferred (d) =>
+      # スキーム違いについても確認をする
+      url2 = app.url.changeScheme(url)
       if bbsmenu[url]?
         d.resolve(bbsmenu[url])
+      else if bbsmenu[url2]?
+        d.resolve(bbsmenu[url2])
       else
         d.reject()
       return
@@ -58,7 +62,10 @@ class app.BoardTitleSolver
   ###
   @searchFromBookmark: (url) ->
     $.Deferred((d) ->
-      if bookmark = app.bookmark.get(url)
+      # スキーム違いについても確認をする
+      url2 = app.url.changeScheme(url)
+      bookmark = app.bookmark.get(url) ? app.bookmark.get(url2)
+      if bookmark
         if app.url.tsld(bookmark.url) is "2ch.net"
           d.resolve(bookmark.title.replace("＠2ch掲示板", ""))
         else
@@ -113,7 +120,8 @@ class app.BoardTitleSolver
   ###
   @searchFromJbbsAPI: (url) ->
     tmp = url.split("/")
-    ajax_path = "http://jbbs.shitaraba.net/bbs/api/setting.cgi/#{tmp[3]}/#{tmp[4]}/"
+    scheme = app.url.getScheme(url)
+    ajax_path = "#{scheme}://jbbs.shitaraba.net/bbs/api/setting.cgi/#{tmp[3]}/#{tmp[4]}/"
 
     $.Deferred (d) ->
       request = new app.HTTP.Request("GET", ajax_path, {

--- a/src/core/Bookmark.ts
+++ b/src/core/Bookmark.ts
@@ -205,7 +205,7 @@ namespace app {
           this.add(entry);
         }
 
-        reg = /^http:\/\/[\w\.]+\//
+        reg = /^https?:\/\/[\w\.]+\//
         tmp = reg.exec(to)[0];
         // スレブックマーク移行
         for(var entry of this.getThreadsByBoardURL(from)) {

--- a/src/core/History.coffee
+++ b/src/core/History.coffee
@@ -106,7 +106,9 @@ class app.History
               key = 0
               length = result.rows.length
               while key < length
-                data.push(result.rows.item(key))
+                item = result.rows.item(key)
+                item.is_https = (app.url.getScheme(item.url) is "https")
+                data.push(item)
                 key++
               d.resolve(data)
               return

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -190,9 +190,9 @@ class app.Thread
         app.util.ch_server_move_detect(app.url.thread_to_board(@url))
           #移転検出時
           .done (newBoardURL) =>
-            tmp = ///^http://(\w+)\.2ch\.net/ ///.exec(newBoardURL)[1]
+            tmp = ///^https?://(\w+)\.2ch\.net/ ///.exec(newBoardURL)[1]
             newURL = @url.replace(
-              ///^(http://)\w+(\.2ch\.net/test/read\.cgi/\w+/\d+/)$///,
+              ///^(https?://)\w+(\.2ch\.net/test/read\.cgi/\w+/\d+/)$///,
               ($0, $1, $2) -> $1 + tmp + $2
             )
 
@@ -316,20 +316,20 @@ class app.Thread
   @return {null|Object}
   ###
   @_getXhrInfo = (url) ->
-    tmp = ///^http://((?:\w+\.)?(\w+\.\w+))/(?:test|bbs)/read\.cgi/
+    tmp = ///^(https?)://((?:\w+\.)?(\w+\.\w+))/(?:test|bbs)/read\.cgi/
       (\w+)/(\d+)/(?:(\d+)/)?$///.exec(url)
     unless tmp then return null
-    switch tmp[2]
+    switch tmp[3]
       when "machi.to"
-        path: "http://#{tmp[1]}/bbs/offlaw.cgi/#{tmp[3]}/#{tmp[4]}/",
+        path: "#{tmp[1]}://#{tmp[2]}/bbs/offlaw.cgi/#{tmp[4]}/#{tmp[5]}/",
         charset: "Shift_JIS"
       when "shitaraba.net"
-        path: "http://jbbs.shitaraba.net/" +
-            "bbs/rawmode.cgi/#{tmp[3]}/#{tmp[4]}/#{tmp[5]}/",
+        path: "#{tmp[1]}://jbbs.shitaraba.net/" +
+            "bbs/rawmode.cgi/#{tmp[4]}/#{tmp[5]}/#{tmp[6]}/",
         charset: "EUC-JP"
       when "2ch.net"
         if app.config.get("format_2chnet") is "dat"
-          path: "http://#{tmp[1]}/#{tmp[3]}/dat/#{tmp[4]}.dat",
+          path: "#{tmp[1]}//#{tmp[2]}/#{tmp[4]}/dat/#{tmp[5]}.dat",
           charset: "Shift_JIS"
         else
           path: tmp[0],
@@ -338,7 +338,7 @@ class app.Thread
         path: tmp[0],
         charset: "Shift_JIS"
       else
-        path: "http://#{tmp[1]}/#{tmp[3]}/dat/#{tmp[4]}.dat",
+        path: "#{tmp[1]}://#{tmp[2]}/#{tmp[4]}/dat/#{tmp[5]}.dat",
         charset: "Shift_JIS"
 
   ###*

--- a/src/core/WriteHistory.coffee
+++ b/src/core/WriteHistory.coffee
@@ -110,7 +110,9 @@ class app.WriteHistory
               key = 0
               length = result.rows.length
               while key < length
-                data.push(result.rows.item(key))
+                item = result.rows.item(key)
+                item.is_https = (app.url.getScheme(item.url) is "https")
+                data.push(item)
                 key++
               d.resolve(data)
               return

--- a/src/core/read_state.coffee
+++ b/src/core/read_state.coffee
@@ -2,13 +2,14 @@ app.read_state = {}
 
 app.read_state._url_filter = (original_url) ->
   original_url = app.url.fix(original_url)
+  scheme = app.url.getScheme(original_url)
 
   original: original_url
   replaced: original_url
-    .replace(/// ^http://\w+\.2ch\.net/ ///, "http://*.2ch.net/")
+    .replace(/// ^https?://\w+\.2ch\.net/ ///, "#{scheme}://*.2ch.net/")
   original_origin: original_url
-    .replace(/// ^(http://\w+\.2ch\.net)/.* ///, "$1")
-  replaced_origin: "http://*.2ch.net"
+    .replace(/// ^(https?://\w+\.2ch\.net)/.* ///, "$1")
+  replaced_origin: "#{scheme}://*.2ch.net"
 
 do ->
   app.read_state._db_open = $.Deferred (deferred) ->

--- a/src/core/thread_search.coffee
+++ b/src/core/thread_search.coffee
@@ -5,13 +5,14 @@ app.module "thread_search", [], (callback) ->
 
     _parse = (x) ->
       def = $.Deferred()
-      app.BoardTitleSolver.ask("http://#{x.server}/#{x.ita}/").done((boardName) ->
+      scheme = app.url.getScheme(x.url)
+      app.BoardTitleSolver.ask("#{scheme}://#{x.server}/#{x.ita}/").done((boardName) ->
         def.resolve(
           url: x.url
           created_at: new Date x.key * 1000
           title: x.subject
           res_count: +x.resno
-          board_url: "http://#{x.server}/#{x.ita}/"
+          board_url: "#{scheme}://#{x.server}/#{x.ita}/"
           board_title: boardName
         )
         return

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -71,7 +71,7 @@ do ->
     #htmlから移転を判定
     .then (html) ->
       $.Deferred (deferred) ->
-        res = ///location\.href="(http://\w+\.2ch\.net/\w*/)"///.exec(html)
+        res = ///location\.href="(https?://\w+\.2ch\.net/\w*/)"///.exec(html)
 
         if res and res[1] isnt old_board_url
           deferred.resolve(res[1])

--- a/src/cs_addlink.coffee
+++ b/src/cs_addlink.coffee
@@ -1,10 +1,10 @@
 regs = [
-  ///^http://(?!find|info|p2)\w+(?:\.2ch\.net|\.2ch\.sc|\.open2ch\.net)/\w+/(?:index\.html)?(?:#\d+)?$///
-  ///^http://(?!itest)\w+(?:\.2ch\.net|\.2ch\.sc|\.open2ch\.net|\.bbspink\.com)/test/read\.cgi/\w+/\d+///
-  ///^http://jbbs\.shitaraba\.net/\w+/\d+/(?:index\.html)?(?:#\d+)?$///
-  ///^http://jbbs\.shitaraba\.net/bbs/read\.cgi/\w+/\d+/\d+///
-  ///^http://\w+\.machi\.to/\w+/(?:index\.html)?(?:#\d+)?$///
-  ///^http://\w+\.machi\.to/bbs/read\.cgi/\w+/\d+///
+  ///^https?://(?!find|info|p2)\w+(?:\.2ch\.net|\.2ch\.sc|\.open2ch\.net)/\w+/(?:index\.html)?(?:#\d+)?$///
+  ///^https?://(?!itest)\w+(?:\.2ch\.net|\.2ch\.sc|\.open2ch\.net|\.bbspink\.com)/test/read\.cgi/\w+/\d+///
+  ///^https?://jbbs\.shitaraba\.net/\w+/\d+/(?:index\.html)?(?:#\d+)?$///
+  ///^https?://jbbs\.shitaraba\.net/bbs/read\.cgi/\w+/\d+/\d+///
+  ///^https?://\w+\.machi\.to/\w+/(?:index\.html)?(?:#\d+)?$///
+  ///^https?://\w+\.machi\.to/bbs/read\.cgi/\w+/\d+///
 ]
 
 open_button_id = "36e5cda5"

--- a/src/image/svg/lock.svg
+++ b/src/image/svg/lock.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+  <rect x="130" y="240" width="240" height="200" rx="35" ry="35" fill="#333" stroke="none"/>
+  <path d="M 180 240 L 180 145 C 190 55 310 55 320 145 L 320 240" fill="none" stroke="#333" stroke-width="30"/>
+</svg>

--- a/src/image/svg/unlock.svg
+++ b/src/image/svg/unlock.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+  <rect x="90" y="240" width="240" height="200" rx="35" ry="35" fill="#333" stroke="none"/>
+  <path d="M 280 240 L 280 145 C 290 55 410 55 420 145 L 420 240" fill="none" stroke="#333" stroke-width="30"/>
+</svg>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -35,22 +35,22 @@
   "content_scripts" : [
     {
       "matches" : [
-        "http://*.2ch.net/*",
-        "http://jbbs.shitaraba.net/*",
-        "http://*.machi.to/*",
-        "http://*.open2ch.net/*",
-        "http://*.2ch.sc/*",
-        "http://*.bbspink.com/*"
+        "*://*.2ch.net/*",
+        "*://jbbs.shitaraba.net/*",
+        "*://*.machi.to/*",
+        "*://*.open2ch.net/*",
+        "*://*.2ch.sc/*",
+        "*://*.bbspink.com/*"
       ],
       "js" : ["/cs_addlink.js"]
     },
     {
       "matches" : [
-        "http://*.2ch.net/test/bbs.cgi*",
-        "http://*.bbspink.com/test/bbs.cgi*",
-        "http://*.2ch.sc/test/bbs.cgi*",
-        "http://*.open2ch.net/test/bbs.cgi*",
-        "http://jbbs.shitaraba.net/bbs/write.cgi/*"
+        "*://*.2ch.net/test/bbs.cgi*",
+        "*://*.bbspink.com/test/bbs.cgi*",
+        "*://*.2ch.sc/test/bbs.cgi*",
+        "*://*.open2ch.net/test/bbs.cgi*",
+        "*://jbbs.shitaraba.net/bbs/write.cgi/*"
       ],
       "js" : ["/write/cs_write.js"],
       "run_at" : "document_end",

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -410,6 +410,7 @@ class UI.ThreadContent
 
         res.num = resNum
         res.class = []
+        scheme = app.url.getScheme(@url)
 
         res = app.ReplaceStrTxt.do(@url, document.title, res)
 
@@ -462,7 +463,7 @@ class UI.ThreadContent
         tmp = (
           res.other
             #be
-            .replace(/<\/div><div class="be .*?"><a href="(http:\/\/be\.2ch\.net\/user\/\d+?)".*?>(.*?)<\/a>/, "<a class=\"beid\" href=\"$1\" target=\"_blank\">$2</a>")
+            .replace(/<\/div><div class="be .*?"><a href="(https?:\/\/be\.2ch\.net\/user\/\d+?)".*?>(.*?)<\/a>/, "<a class=\"beid\" href=\"$1\" target=\"_blank\">$2</a>")
             #タグ除去
             .replace(/<(?!(?:a class="beid".*?|\/a)>).*?(?:>|$)/g, "")
             #.id
@@ -487,7 +488,7 @@ class UI.ThreadContent
             )
             #.beid
             .replace /(?:^| )(BE:(\d+)\-[A-Z\d]+\(\d+\))/,
-              """<a class="beid" href="http://be.2ch.net/test/p.php?i=$3" target="_blank">$1</a>"""
+              """<a class="beid" href="#{scheme}://be.2ch.net/test/p.php?i=$3" target="_blank">$1</a>"""
         )
         # slip追加
         if res.slip?
@@ -512,7 +513,7 @@ class UI.ThreadContent
           res.message
             #imgタグ変換
             .replace(/<img src="([\w]+):\/\/(.*?)".*?>/ig, "$1://$2")
-            .replace(/<img src="\/\/(.*?)".*?>/ig, "http://$1")
+            .replace(/<img src="\/\/(.*?)".*?>/ig, "#{scheme}://$1")
             #Rock54
             .replace(/(?:<small.*?>&#128064;|<i>&#128064;<\/i>)<br>Rock54: (Caution|Warning)\((.+?)\) ?.*?(?:<\/small>)?/ig, "<div class=\"rock54\">&#128064; Rock54: $1($2)</div>")
             #SLIPが変わったという表示
@@ -525,13 +526,13 @@ class UI.ThreadContent
             #Beアイコン埋め込み表示
             .replace ///^(?:\s*sssp|https?)://(img\.2ch\.net/(?:ico|premium)/[\w\-_]+\.gif)\s*<br>///, ($0, $1) =>
               if app.url.tsld(@url) in ["2ch.net", "bbspink.com", "2ch.sc"]
-                """<img class="beicon" src="/img/dummy_1x1.webp" data-src="http://#{$1}"><br>"""
+                """<img class="beicon" src="/img/dummy_1x1.webp" data-src="#{scheme}://#{$1}"><br>"""
               else
                 $0
             #エモーティコン埋め込み表示
             .replace ///(?:\s*sssp|https?)://(img\.2ch\.net/emoji/[\w\-_]+\.gif)\s*///g, ($0, $1) =>
               if app.url.tsld(@url) in ["2ch.net", "bbspink.com", "2ch.sc"]
-                """<img class="beicon emoticon" src="/img/dummy_1x1.webp" data-src="http://#{$1}">"""
+                """<img class="beicon emoticon" src="/img/dummy_1x1.webp" data-src="#{scheme}://#{$1}">"""
               else
                 $0
             #アンカーリンク

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -134,6 +134,7 @@ class UI.ThreadList
               created_at: /\/(\d+)\/$/.exec(msg.bookmark.url)[1] * 1000
               board_url: boardUrl
               board_title: boardName
+              is_https: (app.url.getScheme(msg.bookmark.url) is "https")
             )
             return
           )
@@ -350,6 +351,8 @@ class UI.ThreadList
         trClassName += " ng_thread"
       if item.is_net
         trClassName += " net"
+      if item.is_https
+        trClassName += " https"
       if item.expired and app.config.get("bookmark_show_dat") is "off"
         trClassName += " hidden"
 

--- a/src/view/board.coffee
+++ b/src/view/board.coffee
@@ -35,6 +35,10 @@ app.boot "/view/board.html", ->
   else
     $view.find(".button_write").remove()
 
+  # 現状ではしたらばはhttpsに対応していないので切り替えボタンを隠す
+  if app.url.tsld(url) is "shitaraba.net"
+    $view.find(".button_scheme").remove()
+
   $view
     .find("table")
       .each ->

--- a/src/view/board.haml
+++ b/src/view/board.haml
@@ -22,6 +22,7 @@
       .button.button_reload(title="再読み込み")
       .button.button_bookmark(title="ブックマークする")
       .button.button_write(title="書き込む")
+      .button.button_scheme(title="http/httpsの切り替え")
       .button.button_tool(title="メニュー")
         %ul.hidden
           %li.button_link

--- a/src/view/bookmark.coffee
+++ b/src/view/bookmark.coffee
@@ -125,6 +125,7 @@ app.boot "/view/bookmark.html", ->
           expired: a.expired
           board_url: boardUrl
           board_title: boardName
+          is_https: (app.url.getScheme(a.url) is "https")
         )
         return
       )

--- a/src/view/bookmark.scss
+++ b/src/view/bookmark.scss
@@ -27,6 +27,11 @@ tbody:empty {
   }
 }
 
+tr.https td:first-child:before {
+  content: url(/img/lock_12x12_3a5.webp);
+  vertical-align: middle;
+}
+
 tr.expired td:first-child:before {
   content: "[dat落ち] ";
   color: $color-error;

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -73,6 +73,9 @@
             %input.direct(type="checkbox" name="button_change_netsc_newtab") 2ch netとscの切り替え時に新しいタブで開く
           %br
           %label
+            %input.direct(type="checkbox" name="button_change_scheme_newtab") httpとhttpsの切り替え時に新しいタブで開く
+          %br
+          %label
             %input.direct(type="checkbox" name="open_all_unread_lazy") 未読スレッドを全て開く際遅延ロードする
           %br
           %label

--- a/src/view/history.scss
+++ b/src/view/history.scss
@@ -17,4 +17,8 @@
       content: "閲覧履歴は空です";
     }
   }
+  tr.https td:first-child:before {
+    content: url(/img/lock_12x12_3a5.webp);
+    vertical-align: middle;
+  }
 }

--- a/src/view/inputurl.coffee
+++ b/src/view/inputurl.coffee
@@ -7,8 +7,8 @@ app.boot "/view/inputurl.html", ->
     e.preventDefault()
 
     url = @url.value
-    url = url.replace(/// ^ttp:// ///, "http://")
-    unless /// ^h?ttp:// ///.test(url)
+    url = url.replace(/// ^(ttps?):// ///, "h$1://")
+    unless /// ^h?ttps?:// ///.test(url)
       url = "http://" + url
     guess_res = app.url.guess_type(url)
     if guess_res.type is "thread" or guess_res.type is "board"

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -396,6 +396,7 @@ class app.view.TabContentView extends app.view.PaneContentView
     @_setupNavButton()
     @_setupBookmarkButton()
     @_setupSortItemSelector()
+    @_setupSchemeButton()
     @_setupToolMenu()
     return
 
@@ -489,7 +490,7 @@ class app.view.TabContentView extends app.view.PaneContentView
     if $button.length is 1
       url = @$element.attr("data-url")
 
-      if ///^http://\w///.test(url)
+      if ///^https?://\w///.test(url)
         if app.bookmark.get(url)
           $button.addClass("bookmarked")
         else
@@ -555,6 +556,32 @@ class app.view.TabContentView extends app.view.PaneContentView
 
       $table.table_sort("update", config)
       return
+    return
+
+  ###*
+  @method _setupSchemeButton
+  @private
+  ###
+  _setupSchemeButton: ->
+    $button = @$element.find(".button_scheme")
+
+    if $button.length is 1
+      url = @$element.attr("data-url")
+
+      if ///^https?://\w///.test(url)
+        if app.url.getScheme(url) is "https"
+          $button.addClass("https")
+        else
+          $button.removeClass("https")
+
+        $button.on "click", =>
+          app.message.send "open", {
+            url: app.url.changeScheme(url),
+            new_tab: app.config.get("button_change_scheme_newtab") is "on"
+          }
+          return
+      else
+        $button.remove()
     return
 
   ###*
@@ -631,7 +658,7 @@ class app.view.TabContentView extends app.view.PaneContentView
       return
 
     # 2ch.net/2ch.scに切り替え
-    reg = /http:\/\/\w+\.2ch\.(net|sc)\/\w+\/(.*?)/
+    reg = /https?:\/\/\w+\.2ch\.(net|sc)\/\w+\/(.*?)/
     url = @$element.attr("data-url")
     mode = reg.exec(url)
     if mode

--- a/src/view/sidemenu.coffee
+++ b/src/view/sidemenu.coffee
@@ -13,6 +13,7 @@ app.boot "/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
     a.title = board.title
     a.textContent = board.title
     a.href = app.safe_href(board.url)
+    a.classList.add("https") if app.url.getScheme(board.url) is "https"
     li.appendChild(a)
     li
 

--- a/src/view/sidemenu.scss
+++ b/src/view/sidemenu.scss
@@ -43,6 +43,11 @@ a {
   cursor: pointer;
 }
 
+a.https::before {
+  content: url(/img/lock_12x12_3a5.webp);
+  vertical-align: middle;
+}
+
 .search {
   display: flex;
   padding: 2px;

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -95,6 +95,10 @@ app.boot "/view/thread.html", ->
   else
     $view.find(".button_write").remove()
 
+  # 現状ではしたらばはhttpsに対応していないので切り替えボタンを隠す
+  if app.url.tsld(view_url) is "shitaraba.net"
+    $view.find(".button_scheme").remove()
+
   #リロード処理
   $view.on "request_reload", (e, ex) ->
     #先にread_state更新処理を走らせるために、処理を飛ばす

--- a/src/view/thread.haml
+++ b/src/view/thread.haml
@@ -22,6 +22,7 @@
       .button.button_reload(title="再読み込み")
       .button.button_bookmark(title="ブックマークする")
       .button.button_write(title="書き込む")
+      .button.button_scheme(title="http/httpsの切り替え")
       .button.button_tool(title="メニュー")
         %ul.hidden
           %li.button_link

--- a/src/view/writehistory.scss
+++ b/src/view/writehistory.scss
@@ -17,4 +17,8 @@
       content: "書込履歴は空です";
     }
   }
+  tr.https td:first-child:before {
+    content: url(/img/lock_12x12_3a5.webp);
+    vertical-align: middle;
+  }
 }

--- a/src/write/cs_write.coffee
+++ b/src/write/cs_write.coffee
@@ -61,7 +61,7 @@ do ->
 
   main = ->
     #2ch投稿確認
-    if ///^http://\w+\.(2ch\.net|bbspink\.com|2ch\.sc)/test/bbs\.cgi///.test(location.href)
+    if ///^https?://\w+\.(2ch\.net|bbspink\.com|2ch\.sc)/test/bbs\.cgi///.test(location.href)
       if /書きこみました/.test(document.title)
         send_message_success()
       else if /確認/.test(document.title)
@@ -70,14 +70,14 @@ do ->
         send_message_error()
 
     #したらば投稿確認
-    else if ///^http://jbbs\.shitaraba\.net/bbs/write.cgi/\w+/\d+/(?:\d+|new)/$///.test(location.href)
+    else if ///^https?://jbbs\.shitaraba\.net/bbs/write.cgi/\w+/\d+/(?:\d+|new)/$///.test(location.href)
       if /書きこみました/.test(document.title)
         send_message_success()
       else if /ERROR|スレッド作成規制中/.test(document.title)
         send_message_error()
 
     #open2ch投稿確認
-    if ///^http://\w+\.open2ch\.net/test/bbs\.cgi///.test(location.href)
+    if ///^https?://\w+\.open2ch\.net/test/bbs\.cgi///.test(location.href)
       font = document.getElementsByTagName("font")
       text = document.title
       if font.length > 0 then text += font[0].innerText

--- a/src/write/submit_thread.coffee
+++ b/src/write/submit_thread.coffee
@@ -28,8 +28,8 @@ app.boot "/write/submit_thread.html", ->
         is_same_origin = req.requestHeaders.some((header) -> header.name is "Origin" and (header.value is origin or header.value is "null"))
         if req.method is "POST" and is_same_origin
           if (
-            ///^http://\w+\.(2ch\.net|bbspink\.com|2ch\.sc|open2ch\.net)/test/bbs\.cgi ///.test(req.url) or
-            ///^http://jbbs\.shitaraba\.net/bbs/write\.cgi/ ///.test(req.url)
+            ///^https?://\w+\.(2ch\.net|bbspink\.com|2ch\.sc|open2ch\.net)/test/bbs\.cgi ///.test(req.url) or
+            ///^https?://jbbs\.shitaraba\.net/bbs/write\.cgi/ ///.test(req.url)
           )
             req.requestHeaders.push(name: "Referer", value: arg.url)
 
@@ -47,11 +47,11 @@ app.boot "/write/submit_thread.html", ->
         tabId: tab.id
         types: ["sub_frame"]
         urls: [
-          "http://*.2ch.net/test/bbs.cgi*"
-          "http://*.bbspink.com/test/bbs.cgi*"
-          "http://*.2ch.sc/test/bbs.cgi*"
-          "http://*.open2ch.net/test/bbs.cgi*"
-          "http://jbbs.shitaraba.net/bbs/write.cgi/*"
+          "*://*.2ch.net/test/bbs.cgi*"
+          "*://*.bbspink.com/test/bbs.cgi*"
+          "*://*.2ch.sc/test/bbs.cgi*"
+          "*://*.open2ch.net/test/bbs.cgi*"
+          "*://jbbs.shitaraba.net/bbs/write.cgi/*"
         ]
       }
       ["requestHeaders", "blocking"]
@@ -130,8 +130,8 @@ app.boot "/write/submit_thread.html", ->
           if !keys?
             $view.find(".notice").text("書き込み失敗 - 不明な転送場所")
           else
-            server = arg.url.match(/^http:\/\/(\w+\.(?:2ch\.net|2ch\.sc|bbspink\.com|open2ch\.net)).*/)[1]
-            url = "http://#{server}/test/read.cgi/#{keys[1]}/#{keys[2]}"
+            server = arg.url.match(/^(https?:\/\/\w+\.(?:2ch\.net|2ch\.sc|bbspink\.com|open2ch\.net)).*/)[1]
+            url = "#{server}/test/read.cgi/#{keys[1]}/#{keys[2]}"
             chrome.runtime.sendMessage(type: "written", kind: "own", url: arg.url, thread_url: url, mes: mes, name: name, mail: mail, title: title)
         else if app.url.tsld(arg.url) is "shitaraba.net"
           chrome.runtime.sendMessage(type: "written", kind: "board", url: arg.url, mes: mes, name: name, mail: mail, title: title)
@@ -161,6 +161,7 @@ app.boot "/write/submit_thread.html", ->
 
   document.title = arg.title + "板"
   $view.find("h1").text(arg.title + "板")
+  $view.find("h1").addClass("https") if app.url.getScheme(arg.url) is "https"
   $view.find(".name").val(arg.name)
   $view.find(".mail").val(arg.mail)
   $view.find(".message").val(arg.message)
@@ -171,6 +172,7 @@ app.boot "/write/submit_thread.html", ->
     $view.find("input, textarea").attr("disabled", true)
 
     guess_res = app.url.guess_type(arg.url)
+    scheme = app.url.getScheme(arg.url)
 
     iframe_arg =
       rcrx_name: $view.find(".name").val()
@@ -186,7 +188,7 @@ app.boot "/write/submit_thread.html", ->
         if app.url.tsld(arg.url) is "open2ch.net"
           tmp = arg.url.split("/")
           form_data =
-            action: "http://#{tmp[2]}/test/bbs.cgi"
+            action: "#{scheme}://#{tmp[2]}/test/bbs.cgi"
             charset: "UTF-8"
             input:
               submit: "新規スレッド作成"
@@ -199,7 +201,7 @@ app.boot "/write/submit_thread.html", ->
         else
           tmp = arg.url.split("/")
           form_data =
-            action: "http://#{tmp[2]}/test/bbs.cgi"
+            action: "#{scheme}://#{tmp[2]}/test/bbs.cgi"
             charset: "Shift_JIS"
             input:
               submit: "新規スレッド作成"
@@ -214,7 +216,7 @@ app.boot "/write/submit_thread.html", ->
       else if guess_res.bbs_type is "jbbs"
         tmp = arg.url.split("/")
         form_data =
-          action: "http://jbbs.shitaraba.net/bbs/write.cgi/#{tmp[3]}/#{tmp[4]}/new/"
+          action: "#{scheme}://jbbs.shitaraba.net/bbs/write.cgi/#{tmp[3]}/#{tmp[4]}/new/"
           charset: "EUC-JP"
           input:
             submit: "新規スレッド作成"
@@ -275,4 +277,3 @@ app.boot "/write/submit_thread.html", ->
       return
     return
   return
-

--- a/src/write/submit_thread.scss
+++ b/src/write/submit_thread.scss
@@ -28,6 +28,11 @@ header {
     flex-grow: 1;
     font-size: 18px;
     margin: 0;
+    &.https::before {
+      content: url(/img/lock_19x19_3a5.webp);
+      vertical-align: middle;
+      margin-right: 5px;
+    }
   }
 }
 

--- a/src/write/write.coffee
+++ b/src/write/write.coffee
@@ -28,8 +28,8 @@ app.boot "/write/write.html", ->
         is_same_origin = req.requestHeaders.some((header) -> header.name is "Origin" and (header.value is origin or header.value is "null"))
         if req.method is "POST" and is_same_origin
           if (
-            ///^http://\w+\.(2ch\.net|bbspink\.com|2ch\.sc|open2ch\.net)/test/bbs\.cgi ///.test(req.url) or
-            ///^http://jbbs\.shitaraba\.net/bbs/write\.cgi/ ///.test(req.url)
+            ///^https?://\w+\.(2ch\.net|bbspink\.com|2ch\.sc|open2ch\.net)/test/bbs\.cgi ///.test(req.url) or
+            ///^https?://jbbs\.shitaraba\.net/bbs/write\.cgi/ ///.test(req.url)
           )
             req.requestHeaders.push(name: "Referer", value: arg.url)
 
@@ -47,11 +47,11 @@ app.boot "/write/write.html", ->
         tabId: tab.id
         types: ["sub_frame"]
         urls: [
-          "http://*.2ch.net/test/bbs.cgi*"
-          "http://*.bbspink.com/test/bbs.cgi*"
-          "http://*.2ch.sc/test/bbs.cgi*"
-          "http://*.open2ch.net/test/bbs.cgi*"
-          "http://jbbs.shitaraba.net/bbs/write.cgi/*"
+          "*://*.2ch.net/test/bbs.cgi*"
+          "*://*.bbspink.com/test/bbs.cgi*"
+          "*://*.2ch.sc/test/bbs.cgi*"
+          "*://*.open2ch.net/test/bbs.cgi*"
+          "*://jbbs.shitaraba.net/bbs/write.cgi/*"
         ]
       }
       ["requestHeaders", "blocking"]
@@ -174,6 +174,7 @@ app.boot "/write/write.html", ->
 
   document.title = arg.title
   $view.find("h1").text(arg.title)
+  $view.find("h1").addClass("https") if app.url.getScheme(arg.url) is "https"
   $view.find(".name").val(arg.name)
   $view.find(".mail").val(arg.mail)
   $view.find(".message").val(arg.message)
@@ -192,13 +193,14 @@ app.boot "/write/write.html", ->
 
     $iframe = $("<iframe>", src: "/view/empty.html")
     $iframe.one "load", ->
+      scheme = app.url.getScheme(arg.url)
       #2ch
       if guess_res.bbs_type is "2ch"
         #open2ch
         if app.url.tsld(arg.url) is "open2ch.net"
           tmp = arg.url.split("/")
           form_data =
-            action: "http://#{tmp[2]}/test/bbs.cgi"
+            action: "#{scheme}://#{tmp[2]}/test/bbs.cgi"
             charset: "UTF-8"
             input:
               submit: "書"
@@ -211,7 +213,7 @@ app.boot "/write/write.html", ->
         else
           tmp = arg.url.split("/")
           form_data =
-            action: "http://#{tmp[2]}/test/bbs.cgi"
+            action: "#{scheme}://#{tmp[2]}/test/bbs.cgi"
             charset: "Shift_JIS"
             input:
               submit: "書きこむ"
@@ -226,7 +228,7 @@ app.boot "/write/write.html", ->
       else if guess_res.bbs_type is "jbbs"
         tmp = arg.url.split("/")
         form_data =
-          action: "http://jbbs.shitaraba.net/bbs/write.cgi/#{tmp[5]}/#{tmp[6]}/#{tmp[7]}/"
+          action: "#{scheme}://jbbs.shitaraba.net/bbs/write.cgi/#{tmp[5]}/#{tmp[6]}/#{tmp[7]}/"
           charset: "EUC-JP"
           input:
             TIME: Math.floor(Date.now() / 1000) - 60

--- a/src/write/write.scss
+++ b/src/write/write.scss
@@ -28,6 +28,11 @@ header {
     flex-grow: 1;
     font-size: 18px;
     margin: 0;
+    &.https::before {
+      content: url(/img/lock_19x19_3a5.webp);
+      vertical-align: middle;
+      margin-right: 5px;
+    }
   }
 }
 


### PR DESCRIPTION
現在したらばはhttpsに対応していないようですが、将来的に対応した場合に備えてhttpsにも対応した処理を行っています。
誤操作を防止するために、したらばの場合に限りhttp/httpsの切り替えボタンを非表示にしたほうが良いでしょうか?

アイコン用のSVGファイルはBoxy SVGを使用して作成した後、ImageMagickでの色変更に対応するように修正をしたものです。src/image/img.htmlは使用方法がわからなかったので変更していません。