### PR TITLE
Fix: スレッドオープン時にスクロールが停止しないことがある

### DIFF
--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -208,6 +208,20 @@ class UI.ThreadContent
           max = Math.max(to-change, to+change)
           requestAnimationFrame(_scrollInterval = =>
             before = @container.scrollTop
+            # 画像のロードによる座標変更時の補正
+            if to isnt target.offsetTop + offset
+              to = target.offsetTop + offset
+              min = Math.min(to-change, to+change)
+              max = Math.max(to-change, to+change)
+            # 例外発生時の停止処理
+            if (
+              (change > 0 and @container.scrollTop > max) or
+              (change < 0 and @container.scrollTop < min)
+            )
+              @container.scrollTop = to
+              @_$container.trigger("scrollfinish")
+              return
+            # 正常時の処理
             if min <= @container.scrollTop <= max
               @container.scrollTop = to
               @_$container.trigger("scrollfinish")


### PR DESCRIPTION
画像用コンテナの高さを可変モードにしている場合、スクロール用のアニメーション処理中に画像がロードされて座標が変更された場合に終了判定をすり抜けてしまうことがあったので修正しました。

また、ごく稀に逆方向にスクロールが実行される場合があり、ページの先頭までスクロールをし続ける現象も確認していますが、発生頻度が少ないこともあり、正確な理由まではわからなかったため、例外処理として終了判定を追加しています。
