### PR TITLE
Fix: 戻る/進むボタンの挙動を変更 close #267

### DIFF
--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -466,8 +466,7 @@ class app.view.TabContentView extends app.view.PaneContentView
       if e.which isnt 3
         $this = $(@)
         howToOpen = app.util.get_how_to_open(e)
-        newTab = app.config.get("always_new_tab") is "on"
-        newTab or= howToOpen.new_tab or howToOpen.new_window
+        newTab = howToOpen.new_tab or howToOpen.new_window
         background = howToOpen.background
 
         if not $this.is(".disabled")


### PR DESCRIPTION
“常に新しいタブで開く”がonの場合は戻る/進むボタンを非表示としているが、クリック時の動作としては設定が反映されている。
“常に新しいタブで開く”がonの場合でもnet/scの切り替えを実行した場合に戻るボタンが使用可能になるが、その場合新しいタブが生成されてしまう。
本来“常に新しいタブで開く”がonの場合は使用できないはずの機能なので、設定を無視したほうが動作が自然になると思い修正しました。