### PR TITLE
net/sc切り替え機能の修正と設定画面のバグ修正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -284,6 +284,7 @@ namespace app {
       ["no_writehistory", "off"],
       ["user_css", ""],
       ["bbsmenu", "http://kita.jikkyo.org/cbm/cbm.cgi/20.p0.m0.jb.vs.op.sc.nb.bb/-all/bbsmenu.html"],
+      ["bbsmenu_update_interval", "7"],
       ["useragent", ""],
       ["format_2chnet", "html"],
       ["sage_flag", "on"],

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -151,6 +151,70 @@ namespace app {
         });
       });
     }
+
+    var serverNet = new Map<string, string>();
+    var serverSc = new Map<string, string>();
+
+    export function pushBoardToServerInfo (boardInfoNet: any, boardInfoSc: any): void {
+      var item: any;
+      var tmp: string[];
+
+      if (boardInfoNet.length > 0) {
+        serverNet.clear();
+      }
+      for (item of boardInfoNet) {
+        tmp = /https?:\/\/(\w+)\.2ch\.net\/(\w+)\//.exec(item.url);
+        if (tmp === null) {
+          continue;
+        }
+        if (serverNet.has(tmp[2]) === false) {
+          serverNet.set(tmp[2], tmp[1]);
+        }
+      }
+
+      if (boardInfoSc.length > 0) {
+        serverSc.clear();
+      }
+      for (item of boardInfoSc) {
+        tmp = /https?:\/\/(\w+)\.2ch\.sc\/(\w+)\//.exec(item.url);
+        if (tmp === null) {
+          continue;
+        }
+        if (serverSc.has(tmp[2]) === false) {
+          serverSc.set(tmp[2], tmp[1]);
+        }
+      }
+      return;
+    }
+
+    export function exchangeNetSc (url: string): string {
+      var mode: string[];
+      var server: string = null;
+      var target: string = null;
+      var resUrl: string = null;
+
+      mode = /(https?):\/\/(\w+)\.2ch\.(net|sc)\/test\/read\.cgi\/(\w+)\/(\d+)\//.exec(url);
+      if (mode === null) {
+        return null;
+      }
+
+      if (mode[3] === "net") {
+        if (serverSc.has(mode[4]) === true) {
+          server = serverSc.get(mode[4]);
+          target = "sc";
+        }
+      } else {
+        if (serverNet.has(mode[4]) === true) {
+          server = serverNet.get(mode[4]);
+          target = "net";
+        }
+      }
+
+      if (server !== null) {
+        resUrl = mode[1] + "://" + server + ".2ch." + target + "/test/read.cgi/" + mode[4] + "/" + mode[5] + "/";
+      }
+      return resUrl;
+    }
   }
 }
 
@@ -180,5 +244,7 @@ namespace app {
     export var buildQuery = app.URL.buildQueryString;
     export const SHORT_URL_REG = app.URL.SHORT_URL_REG;
     export var expandShortURL = app.URL.expandShortURL;
+    export var pushBoardToServerInfo = app.URL.pushBoardToServerInfo;
+    export var exchangeNetSc = app.URL.exchangeNetSc;
   }
 }

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -189,10 +189,7 @@ app.boot "/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
           .addClass("done")
           .text("更新完了")
 
-        iframe = parent.document.querySelector("iframe[src^=\"/view/sidemenu.html\"]")
-        if iframe
-          tmp = JSON.stringify(type: "request_reload")
-          iframe.contentWindow.postMessage(tmp, location.origin)
+        # sidemenuの表示時に設定されたコールバックが実行されるので、特別なことはしない
 
         #TODO [board_title_solver]も更新するよう変更
       else
@@ -456,6 +453,7 @@ app.boot "/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
   resetBBSMenu = ->
     app.config.del("bbsmenu").then ->
       $view.find(".direct.bbsmenu").val(app.config.get("bbsmenu"))
+      $(".bbsmenu_reload").trigger("click")
 
   if $view.find(".direct.bbsmenu").val() is ""
     resetBBSMenu()
@@ -463,6 +461,8 @@ app.boot "/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
   $view.find(".direct.bbsmenu").on "change", ->
     if $view.find(".direct.bbsmenu").val() isnt ""
       $(".bbsmenu_reload").trigger("click")
+    else
+      resetBBSMenu()
     return
 
   $view.find(".bbsmenu_reset").on "click", ->

--- a/src/view/config.haml
+++ b/src/view/config.haml
@@ -412,6 +412,8 @@
 
           %button.bbsmenu_reload(type="button") 板一覧の更新
           %span.bbsmenu_reload_status
+          更新間隔:
+          %input.direct(type="number" name="bbsmenu_update_interval" min="1" value="7") 日
 
       %section
         %h2 上級者向け機能

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -662,12 +662,12 @@ class app.view.TabContentView extends app.view.PaneContentView
     mode = reg.exec(url)
     if mode
       @$element.find(".button_change_netsc").on "click", =>
-        from = ".2ch." + mode[1] + "/"
-        to = ".2ch." + (if mode[1] is 'net' then 'sc' else 'net') + "/"
-        app.message.send "open", {
-          url: url.replace(from, to),
-          new_tab: app.config.get("button_change_netsc_newtab") is "on"
-        }
+        newUrl = app.url.exchangeNetSc(url)
+        if newUrl
+          app.message.send "open", {
+            url: newUrl,
+            new_tab: app.config.get("button_change_netsc_newtab") is "on"
+          }
         return
     else
       @$element.find(".button_change_netsc").remove()


### PR DESCRIPTION
1. net/scの切り替えを板一覧の情報から行うように変更しました。
2. 板一覧の更新間隔を設定可能にしました。(初期値7日)
3. 設定画面でbbsmenuのurlを編集した際に、2回目以降の編集が反映されない、メニューの更新処理が無限ループに入っていた、リセットボタンをクリックしてもメニューに反映されない、urlがブランクの場合は強制リセットとする、以上4点について修正しました。

1.については、当初はDBに書き出す形式にしていましたが、その必要性に疑問が生じたためオンメモリで変換を行う形で実装しています。
3.については、BBSMenu.get()を実行すると過去に実行したコールバックが呼び出されることから、更新時のsidemenuに対するイベントメッセージの送信を止めるようにしました。

コールバックの動作が謎すぎてかなり遠回りしていたため時間が予想以上にかかってしまいました。すみません。
本当にこれで良いのか多々疑問があります。間違い等があれば指摘してくだい。