### PR TITLE
ApplicationからExtensionへの移行

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -33,6 +33,7 @@ args =
   outputPath: "./debug"
   manifestPath: "./src/manifest.json"
   appTsPath: "./src/app.ts"
+  backgroundCoffeePath: "./src/background.coffee"
   csaddlinkCoffeePath: "./src/cs_addlink.coffee"
   appCoreCoffeePath: "./src/core/*.coffee"
   appCoreTsPath: "./src/core/*.ts"
@@ -93,6 +94,8 @@ args =
     locals: manifest
 imgs = [
   "read.crx_48x48.png"
+  "read.crx_38x38.png"
+  "read.crx_19x19.png"
   "read.crx_16x16.png"
   "close_16x16.webp"
   "dummy_1x1.webp"
@@ -169,6 +172,7 @@ gulp.task "pack", (cb) ->
 
 gulp.task "watch", ["default"], ->
   gulp.watch([args.appTsPath, "./src/global.d.ts"], ["app.js"])
+  gulp.watch(args.backgroundCoffeePath, ["background.js"])
   gulp.watch(args.csaddlinkCoffeePath, ["cs_addlink.js"])
   gulp.watch([args.appCoreTsPath, args.appCoreCoffeePath], ["app_core.js"])
   gulp.watch([args.uiTsPath, args.uiCoffeePath], ["ui.js"])
@@ -219,12 +223,19 @@ gulp.task "crx", (cb) ->
 
 #compile
 ##js
-gulp.task "js", ["app.js", "cs_addlink.js", "app_core.js", "ui.js", "viewjs", "zombie.js", "writejs"]
+gulp.task "js", ["app.js", "background.js", "cs_addlink.js", "app_core.js", "ui.js", "viewjs", "zombie.js", "writejs"]
 
 gulp.task "app.js", ->
   return gulp.src args.appTsPath
     .pipe(plumber(errorHandler: notify.onError("Error: <%= error.toString() %>")))
     .pipe(ts(args.tsOptions, ts.reporter.nullReporter()))
+    .pipe(gulp.dest(args.outputPath))
+
+gulp.task "background.js", ->
+  return gulp.src args.backgroundCoffeePath
+    .pipe(plumber(errorHandler: notify.onError("Error: <%= error.toString() %>")))
+    .pipe(changed(args.outputPath, extension: ".js"))
+    .pipe(coffee(args.coffeeOptions))
     .pipe(gulp.dest(args.outputPath))
 
 gulp.task "cs_addlink.js", ->

--- a/src/background.coffee
+++ b/src/background.coffee
@@ -44,3 +44,61 @@ chrome.browserAction.onClicked.addListener( ->
         )
     )
 )
+
+# 対応URLのチェック
+isSupportedURL = (url) ->
+  if /^https?:\/\/[\w\.]+\/test\/read\.cgi\/\w+\/\d+\/.*?/.test(url)
+    return true
+  else if /^https?:\/\/\w+\.machi\.to\/bbs\/read\.cgi\/\w+\/\d+\/.*?/.test(url)
+    return true
+  else if /^https?:\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/bbs\/read(?:_archive)?\.cgi\/\w+\/\d+\/\d+\/.*?/.test(url)
+    return true
+  else if /^https?:\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/\w+\/\d+\/storage\/\d+\.html$/.test(url)
+    return true
+  else if /^https?:\/\/[\w\.]+\/\w+\/(?:#.*)?/.test(url)
+    return true
+  else if /^https?:\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/\w+\/\d+\/(?:#.*)?/.test(url)
+    return true
+  return false
+
+# コンテキストメニューの作成
+chrome.contextMenus.create({
+  id: "open_link_in_rcrx",
+  title: "リンクをread.crx-2で開く",
+  contexts: ["link"],
+  documentUrlPatterns: ["http://*/*", "https://*/*", "file://*/*"],
+  targetUrlPatterns: [
+    "*://*.2ch.net/*",
+    "*://*.2ch.sc/*",
+    "*://*.open2ch.net/*",
+    "*://*.bbspink.com/*",
+    "*://jbbs.shitaraba.net/*",
+    "*://jbbs.livedoor.jp/*",
+    "*://*.machi.to/*"
+  ]
+})
+
+# コンテキストメニューのクリック時の動作
+chrome.contextMenus.onClicked.addListener( (info, tab) ->
+  return unless info.menuItemId is "open_link_in_rcrx"
+
+  url = info.linkUrl
+  # 対応URLであるか確認
+  unless isSupportedURL(url)
+    new Notification("未対応のURLです")
+    return
+  # 実行中のread.crxを探す
+  searchRcrx()
+    # 存在すればそれを開く
+    .then( (tab) ->
+      chrome.windows.update(tab.windowId, {focused: true})
+      chrome.tabs.update(tab.id, {highlighted: true})
+      chrome.runtime.sendMessage({type: "open", query: url})
+      return
+    )
+    # 存在しなければタブを作成する
+    .catch( ->
+      chrome.tabs.create({url: "/view/index.html?q=#{url}"})
+    )
+  return
+)

--- a/src/background.coffee
+++ b/src/background.coffee
@@ -1,0 +1,46 @@
+# 現在のタブが自分自身であるか確認する
+isCurrentTab = ->
+  return new Promise( (resolve, reject) ->
+    id = chrome.runtime.id
+    chrome.tabs.query(
+      {active: true, lastFocusedWindow: true},
+      (tabs) ->
+        if tabs[0].url.startsWith("chrome-extension://#{id}")
+          return resolve()
+        else
+          return reject()
+    )
+  )
+
+# 実行中のread.crxを探す
+searchRcrx = ->
+  return new Promise( (resolve, reject) ->
+    id = chrome.runtime.id
+    chrome.tabs.query(
+      {url: "chrome-extension://#{id}/*"},
+      (tabs) ->
+        if tabs.length is 0
+          return reject()
+        else
+          return resolve(tabs[0])
+    )
+  )
+
+# アイコンクリック時の動作
+chrome.browserAction.onClicked.addListener( ->
+  isCurrentTab()
+    # 現在のタブが自分自身である場合は何もしない
+    .catch( ->
+      # 実行中のread.crxを探す
+      searchRcrx()
+        # 存在すればそれを開く
+        .then( (tab) ->
+          chrome.windows.update(tab.windowId, {focused: true})
+          chrome.tabs.update(tab.id, {highlighted: true})
+        )
+        # 存在しなければタブを作成する
+        .catch( ->
+          chrome.tabs.create({url: "/view/index.html"})
+        )
+    )
+)

--- a/src/common.scss
+++ b/src/common.scss
@@ -17,7 +17,7 @@ $color-error: #BF3F3F;
 $color-https: #109020;
 
 @mixin common {
-  button, input, select, textarea {
+  header, body {
     font-family: inherit;
   }
 

--- a/src/core/ContextMenus.coffee
+++ b/src/core/ContextMenus.coffee
@@ -80,5 +80,9 @@ class app.contextMenus
   @method removeAll
   ###
   @removeAll: ->
-    chrome.contextMenus.removeAll()
+    # removeAll()を使うとbackgroundのコンテキストメニューも削除されてしまうので個別に削除する
+    @remove("add_selection_to_ngwords")
+    @remove("add_link_to_ngwords")
+    @remove("add_media_to_ngwords")
+    @remove("open_link_with_res_number")
     return

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,10 +22,17 @@
     "http://*/",
     "https://*/"
   ],
-  "app" : {
-    "launch" : {
-      "local_path" : "/view/index.html"
-    }
+  "background" : {
+    "scripts" : [
+      "background.js"
+    ]
+  },
+  "browser_action" : {
+    "default_icon" : {
+      "19" : "img/read.crx_19x19.png",
+      "38" : "img/read.crx_38x38.png"
+    },
+    "default_title" : "read.crx-2を開く"
   },
   "icons" : {
     "128" : "img/read.crx_128x128.png",

--- a/src/view/config.scss
+++ b/src/view/config.scss
@@ -4,15 +4,16 @@
 @include tab-content;
 
 html {
-  font-size: 13px;
   background-color: #fff;
 }
 
 body {
+  font-size: 13px;
   position: relative;
 }
 
 header {
+  font-size: 13px;
   position: absolute;
   top: 0;
   left: 0;
@@ -46,7 +47,7 @@ header {
 }
 
 section {
-  padding: 1rem;
+  padding: 1em;
 
   display: flex;
   > div {
@@ -62,11 +63,11 @@ section {
 }
 
 section > h2 {
-  font-size: 1.125rem;
+  font-size: 1.125em;
   font-weight: normal;
-  margin: 0 1rem 0 0;
+  margin: 0 1em 0 0;
   text-align: right;
-  width: 10rem;
+  width: 10em;
 }
 
 label {
@@ -82,9 +83,9 @@ section button {
 }
 
 .version {
-  font-size: 0.9rem;
-  margin: 0.5rem;
-  padding: 0.5rem;
+  font-size: 0.9em;
+  margin: 0.5em;
+  padding: 0.5em;
   border-radius: 3px;
   border: 1px solid #aaaaaa;
 

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -657,6 +657,8 @@ app.main = ->
       localStorage.tab_state = JSON.stringify(data)
     #コンテキストメニューの削除
     app.contextMenus.removeAll()
+    # 終了通知の送信
+    chrome.runtime.sendMessage({type: "exit_rcrx"})
     return
 
   #openメッセージ受信部

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -16,7 +16,7 @@
   100% {transform: rotate(315deg);}
 }
 
-html {
+header, body {
   font-size: 15px;
 }
 

--- a/src/write/submit_thread.scss
+++ b/src/write/submit_thread.scss
@@ -12,16 +12,18 @@ html, body {
 }
 
 html {
-  font-size: 14px;
   background-color: #f5f5f5;
-  color: #444444;
 }
 
 body {
+  font-size: 14px;
+  color: #444444;
   padding: 8px;
 }
 
 header {
+  font-size: 14px;
+  color: #444444;
   margin: 0 0 5px 0;
   display: flex;
   > h1 {

--- a/src/write/write.scss
+++ b/src/write/write.scss
@@ -12,16 +12,18 @@ html, body {
 }
 
 html {
-  font-size: 14px;
   background-color: #f5f5f5;
-  color: #444444;
 }
 
 body {
+  font-size: 14px;
+  color: #444444;
   padding: 8px;
 }
 
 header {
+  font-size: 14px;
+  color: #444444;
   margin: 0 0 5px 0;
   display: flex;
   > h1 {


### PR DESCRIPTION
chrome.tabs.create()で起動しても2重起動にはなりませんが、既に起動済みの場合にタブが一瞬出て消えるのが目障りなので、起動方法を変更しました。

コンテキストメニューについての補足
documentUrlPatterns : "<all_urls>"を指定するとread.crx自身も含まれてしまうため、スキームごとの指定にしてあります。
targetUrlPatterns : 対象パターンをできるだけ絞りたかったのですが、掲示板のURLを対象に含めると`jump.2ch.net`も含まれてしまうため、有効性チェックを追加してパターンはシンプルな形にしました。