### PR TITLE
Fix: 板一覧の取得で無限ループの可能性があった

### DIFF
--- a/src/view/sidemenu.coffee
+++ b/src/view/sidemenu.coffee
@@ -128,7 +128,10 @@ app.boot "/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
           accordion.update()
 
         # 2ch.netと2ch.scの切替用情報の取得
-        if !modeFlag.net or !modeFlag.sc
+        if (
+          res.url is app.config.get("bbsmenu") and
+          !modeFlag.net or !modeFlag.sc
+        )
           loopCount = 0
           intervalID = setInterval( ->
             # 一旦待機させるため1回目をスキップ


### PR DESCRIPTION
bbsmenuの設定で、2ch.netと2ch.scのどちらか一方のみの設定になっている場合に無限ループが発生していました。

掲示板で報告のあった処理が重くなる現象の原因であろうと思います。