### PR TITLE
thread.coffeeからLazyLoad.tsにイベントが伝わっていない

### DIFF
--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -155,7 +155,7 @@ app.boot "/view/thread.html", ->
 
       #スクロールされなかった場合も余所の処理を走らすためにscrollを発火
       unless on_scroll
-        $content.triggerHandler("scroll")
+        $content[0].dispatchEvent(new Event("scroll"))
 
       #二度目以降のread_state_attached時
       $view.on "read_state_attached", ->
@@ -715,7 +715,7 @@ app.boot "/view/thread.html", ->
           return
         .on "input", ->
           return if _isComposing
-          $content.triggerHandler("searchstart")
+          $content[0].dispatchEvent(new Event("searchstart"))
           if @value isnt ""
             if typeof search_stored_scrollTop isnt "number"
               search_stored_scrollTop = $content.scrollTop()
@@ -743,7 +743,7 @@ app.boot "/view/thread.html", ->
                 .text(hit_count + "hit")
 
             if scrollTop is $content.scrollTop()
-              $content.triggerHandler("scroll")
+              $content[0].dispatchEvent(new Event("scroll"))
           else
             $view
               .find(".content")
@@ -760,7 +760,7 @@ app.boot "/view/thread.html", ->
               $content.scrollTop(search_stored_scrollTop)
               search_stored_scrollTop = null
 
-          $content.triggerHandler("searchfinish")
+          $content[0].dispatchEvent(new Event("searchfinish"))
           return
 
         .on "keyup", (e) ->
@@ -871,7 +871,7 @@ app.boot "/view/thread.html", ->
   $view.on "lazyload-load", ".thumbnail > a > img.image, .thumbnail > video", ->
     # Lazyloadを実行させるためにスクロールを発火
     if app.config.get("image_height_fix") is "off"
-      $content.triggerHandler("scroll")
+      $content[0].dispatchEvent(new Event("scroll"))
     # マウスオーバーによるズームの設定
     app.view_thread._setupHoverZoom(@)
     return

--- a/src/write/submit_thread.coffee
+++ b/src/write/submit_thread.coffee
@@ -194,7 +194,7 @@ app.boot "/write/submit_thread.html", ->
 
     iframe_arg =
       rcrx_name: $view.C("name")[0].value
-      rcrx_mail: if $view.C("sage")[0].checked then "sage" else $view.C("mail").value
+      rcrx_mail: if $view.C("sage")[0].checked then "sage" else $view.C("mail")[0].value
       rcrx_title: $view.C("title")[0].value
       rcrx_message: $view.C("message")[0].value
 


### PR DESCRIPTION
jqueryのバージョンアップと名前空間の違いによるものと思われますが、イベントが伝わっていなかったので以下の現象が発生していました。
- 初めて開いたスレッドの1ページ目にある画像がロードされない
- 検索にヒットした場合に画像がロードされない
- 検索中に無駄な画像のロードが発生する

LazyLoadにも伝える必要があるイベントの発火方法を`triggerHandler`から`dispatchEvent`に変更しました。

また、スレ立て時にメール欄の入力内容が反映されていなかったので修正しました。