### PR TITLE
Update: レス番号を指定してスレッドを開けるようにする

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -239,6 +239,7 @@ namespace app {
       ["button_change_netsc_newtab", "off"],
       ["button_change_scheme_newtab", "off"],
       ["open_all_unread_lazy", "on"],
+      ["enable_link_with_res_number", "on"],
       ["dblclick_reload", "on"],
       ["auto_load_second", "0"],
       ["auto_load_second_board", "0"],

--- a/src/core/ContextMenus.coffee
+++ b/src/core/ContextMenus.coffee
@@ -33,6 +33,22 @@ class app.contextMenus
       contexts: ["image", "video", "audio"],
       documentUrlPatterns: [viewThread]
     )
+    @create(
+      id: "open_link_with_res_number",
+      title: "レス番号を指定してリンクを開く",
+      contexts: ["link"],
+      enabled: false,
+      targetUrlPatterns: [
+        "*://*.2ch.net/*",
+        "*://*.2ch.sc/*",
+        "*://*.open2ch.net/*",
+        "*://*.bbspink.com/*",
+        "*://jbbs.shitaraba.net/*",
+        "*://jbbs.livedoor.jp/*",
+        "*://*.machi.to/*"
+      ],
+      documentUrlPatterns: [viewThread]
+    )
     return
 
   ###*

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -83,6 +83,25 @@ namespace app {
       return protocol + "://" + urlstr.slice(split+3);
     }
 
+    export function getResNumber (urlstr: string): string|null {
+      var tmp: string[]|null;
+
+      tmp = /^https?:\/\/[\w\.]+\/test\/read\.cgi\/\w+\/\d+\/(\d+).*?$/.exec(urlstr);
+      if (tmp !== null) {
+        return tmp[1];
+      }
+      tmp = /^https?:\/\/\w+\.machi\.to\/bbs\/read\.cgi\/\w+\/\d+\/(\d+).*?$/.exec(urlstr);
+      if (tmp !== null) {
+        return tmp[1];
+      }
+      tmp = /^https?:\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/bbs\/read(?:_archive)?\.cgi\/\w+\/\d+\/\d+\/(\d+).*?$/.exec(urlstr);
+      if (tmp !== null) {
+        return tmp[1];
+      }
+
+      return null;
+    }
+
     export function threadToBoard (url:string):string {
       return (
         fix(url)

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -359,6 +359,8 @@ class UI.ThreadList
 
       if item.thread_number?
         tmpHTML += " data-thread_number=\"#{app.escapeHtml(""+item.thread_number)}\""
+      if @_flg.writtenRes and item.res > 0
+        tmpHTML += " data-written_res_num=\"#{item.res}\""
 
       tmpHTML += ">"
 

--- a/src/view/config.pug
+++ b/src/view/config.pug
@@ -81,6 +81,13 @@ html.view.view_config(data-app-version=version)
             | マウスホイールでタブを切り替える
 
       section
+        h2 リンク
+        div
+          label
+            input.direct(type="checkbox" name="enable_link_with_res_number")
+            | URLで指定されたレス番号を有効にする(範囲指定は無視します)
+
+      section
         h2 更新
         div
           label

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -676,7 +676,10 @@ app.main = ->
       if $li.length
         $li.closest(".tab").data("tab").update($li.attr("data-tabid"), selected: true)
         if message.url isnt "bookmark" #ブックマーク更新は時間がかかるので例外扱い
-          tmp = JSON.stringify(type: "request_reload")
+          tmp = JSON.stringify({
+            type: "request_reload",
+            written_res_num: if message.written_res_num? then message.written_res_num else null
+          })
           $iframe = $view.find("iframe[data-tabid=\"#{$li.attr("data-tabid")}\"]")
           $iframe[0].contentWindow.postMessage(tmp, location.origin)
       else
@@ -700,9 +703,11 @@ app.main = ->
             selected: true
             locked: message.locked
           })
+        writtenResNum = if message.written_res_num? then message.written_res_num else ""
         $view
           .find("iframe[data-tabid=\"#{tabId}\"]")
             .attr("data-url", iframe_info.url)
+            .attr("data-written_res_num", writtenResNum)
     return
 
   #openリクエストの監視

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -305,7 +305,9 @@ app.boot "/view/index.html", ->
       history.replaceState(null, null, "/view/index.html")
       app.main()
       if query
-        app.message.send("open", url: query, new_tab: true)
+        paramResNumFlag = (app.config.get("enable_link_with_res_number") is "on")
+        paramResNum = if paramResNumFlag then app.URL.getResNumber(query) else null
+        app.message.send("open", url: query, new_tab: true, param_res_num: paramResNum)
 
 app.view_setup_resizer = ->
   MIN_TAB_HEIGHT = 100
@@ -678,7 +680,8 @@ app.main = ->
         if message.url isnt "bookmark" #ブックマーク更新は時間がかかるので例外扱い
           tmp = JSON.stringify({
             type: "request_reload",
-            written_res_num: if message.written_res_num? then message.written_res_num else null
+            written_res_num: if message.written_res_num? then message.written_res_num else null,
+            param_res_num: if message.param_res_num? then message.param_res_num else null
           })
           $iframe = $view.find("iframe[data-tabid=\"#{$li.attr("data-tabid")}\"]")
           $iframe[0].contentWindow.postMessage(tmp, location.origin)
@@ -704,16 +707,20 @@ app.main = ->
             locked: message.locked
           })
         writtenResNum = if message.written_res_num? then message.written_res_num else ""
+        paramResNum = if message.param_res_num? then message.param_res_num else ""
         $view
           .find("iframe[data-tabid=\"#{tabId}\"]")
             .attr("data-url", iframe_info.url)
             .attr("data-written_res_num", writtenResNum)
+            .attr("data-param_res_num", paramResNum)
     return
 
   #openリクエストの監視
   chrome.runtime.onMessage.addListener (request) ->
     if request.type is "open"
-      app.message.send("open", url: request.query, new_tab: true)
+      paramResNumFlag = (app.config.get("enable_link_with_res_number") is "on")
+      paramResNum = if paramResNumFlag then app.URL.getResNumber(request.query) else null
+      app.message.send("open", url: request.query, new_tab: true, param_res_num: paramResNum)
 
   #書き込み完了メッセージの監視
   chrome.runtime.onMessage.addListener (request) ->

--- a/src/view/inputurl.coffee
+++ b/src/view/inputurl.coffee
@@ -12,7 +12,9 @@ app.boot "/view/inputurl.html", ->
       url = "http://" + url
     guess_res = app.URL.guessType(url)
     if guess_res.type is "thread" or guess_res.type is "board"
-      app.message.send("open", {url, new_tab: true})
+      paramResNumFlag = (app.config.get("enable_link_with_res_number") is "on")
+      paramResNum = if paramResNumFlag then app.URL.getResNumber(url) else null
+      app.message.send("open", {url, new_tab: true, param_res_num: paramResNum})
       parent.postMessage(JSON.stringify(type: "request_killme"), location.origin)
     else
       ele = $view

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -91,12 +91,13 @@ class app.view.View
         if e.which isnt 3
           url = @getAttribute("data-href") or @href
           title = @getAttribute("data-title") or @textContent
+          writtenResNum = @getAttribute("data-written_res_num")
           howToOpen = app.util.get_how_to_open(e)
           newTab = app.config.get("always_new_tab") is "on"
           newTab or= howToOpen.new_tab or howToOpen.new_window
           background = howToOpen.background
 
-          app.message.send("open", {url, new_tab: newTab, background, title})
+          app.message.send("open", {url, new_tab: newTab, background, title, written_res_num: writtenResNum})
         return
     @element.on("click", (e) ->
       e.preventDefault() if e.target?.hasClass("open_in_rcrx")
@@ -385,7 +386,8 @@ class app.view.PaneContentView extends app.view.IframeView
             name: if message.name? then message.name else null,
             mail: if message.mail? then message.mail else null,
             title: if message.title? then message.title else null,
-            thread_url: if message.thread_url? then message.thread_url else null
+            thread_url: if message.thread_url? then message.thread_url else null,
+            written_res_num: if message.written_res_num? then message.written_res_num else null
           )
 
         # tab_selected(postMessage) -> tab_selected(event) 翻訳処理

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -92,12 +92,21 @@ class app.view.View
           url = @getAttribute("data-href") or @href
           title = @getAttribute("data-title") or @textContent
           writtenResNum = @getAttribute("data-written_res_num")
+          paramResNum = null
+          if (
+            (app.config.get("enable_link_with_res_number") is "on" and
+             @getAttribute("toggle_param_res_num") isnt "on") or
+            (app.config.get("enable_link_with_res_number") is "off" and
+             @getAttribute("toggle_param_res_num") is "on")
+          )
+            paramResNum = @getAttribute("data-param_res_num")
+          @removeAttribute("toggle_param_res_num")
           howToOpen = app.util.get_how_to_open(e)
           newTab = app.config.get("always_new_tab") is "on"
           newTab or= howToOpen.new_tab or howToOpen.new_window
           background = howToOpen.background
 
-          app.message.send("open", {url, new_tab: newTab, background, title, written_res_num: writtenResNum})
+          app.message.send("open", {url, new_tab: newTab, background, title, written_res_num: writtenResNum, param_res_num: paramResNum})
         return
     @element.on("click", (e) ->
       e.preventDefault() if e.target?.hasClass("open_in_rcrx")
@@ -387,7 +396,8 @@ class app.view.PaneContentView extends app.view.IframeView
             mail: if message.mail? then message.mail else null,
             title: if message.title? then message.title else null,
             thread_url: if message.thread_url? then message.thread_url else null,
-            written_res_num: if message.written_res_num? then message.written_res_num else null
+            written_res_num: if message.written_res_num? then message.written_res_num else null,
+            param_res_num: if message.param_res_num? then message.param_res_num else null
           )
 
         # tab_selected(postMessage) -> tab_selected(event) 翻訳処理

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -47,6 +47,10 @@ app.boot "/view/thread.html", ->
     alert("不正な引数です")
     return
   view_url = app.URL.fix(view_url)
+  jumpResNum = -1
+  iframe = parent.document.querySelector("iframe[data-url=\"#{view_url}\"]")
+  if iframe
+    jumpResNum = +iframe.getAttribute("data-written_res_num")
 
   $view = $(document.documentElement)
   $view.attr("data-url", view_url)
@@ -115,8 +119,17 @@ app.boot "/view/thread.html", ->
   $view.on "request_reload", (e, ex) ->
     #先にread_state更新処理を走らせるために、処理を飛ばす
     app.defer ->
-      return if $view.hasClass("loading")
-      return if $view.find(".button_reload").hasClass("disabled")
+      if ex?.written_res_num?
+        jumpResNum = +ex.written_res_num
+      if (
+        $view.hasClass("loading") or
+        $view.find(".button_reload").hasClass("disabled")
+      )
+        if jumpResNum > 0
+          threadContent.scrollTo(jumpResNum, true, -60)
+          threadContent.select(jumpResNum, true)
+          jumpResNum = -1
+        return
 
       app.view_thread._draw($view, ex?.force_update, (thread) ->
         if ex?.mes? and app.config.get("no_writehistory") is "off"
@@ -130,6 +143,7 @@ app.boot "/view/thread.html", ->
                 app.WriteHistory.add(view_url, i+1, document.title, name, mail, ex.name, ex.mail, ex.mes, date.valueOf())
               break
             i--
+          jumpResNum = -1
         return
       )
     return
@@ -150,7 +164,13 @@ app.boot "/view/thread.html", ->
         threadContent.checkImageExists(true)
 
       $last = $content.find(".last")
-      if $last.length is 1
+      lastNum = +$content.children("article:last-child").find(".num").text()
+      # 指定レス番号へ
+      if jumpResNum > 0 and jumpResNum <= lastNum
+        threadContent.scrollTo(jumpResNum, true, -60)
+        threadContent.select(jumpResNum, true)
+      # 最終既読位置へ
+      else if $last.length is 1
         threadContent.scrollTo(+$last.find(".num").text())
 
       #スクロールされなかった場合も余所の処理を走らすためにscrollを発火
@@ -163,12 +183,17 @@ app.boot "/view/thread.html", ->
         move_mode = if parseInt(app.config.get("auto_load_second")) >= 5000 then app.config.get("auto_load_move") else "new"
         switch move_mode
           when "new"
-            $tmp = $content.children(".last.received + article")
-            # 新着が存在しない場合はスクロールを実行するためにレスを探す
-            $tmp = $content.children("article.last") unless $tmp.length is 1
-            $tmp = $content.children("article.read") unless $tmp.length is 1
-            $tmp = $content.children("article:last-child") unless $tmp.length is 1
-            threadContent.scrollTo(+$tmp.find(".num").text(), true, -100) if $tmp.length is 1
+            lastNum = +$content.children("article:last-child").find(".num").text()
+            if jumpResNum > 0 and jumpResNum <= lastNum
+              threadContent.scrollTo(jumpResNum, true, -60)
+              threadContent.select(jumpResNum, true)
+            else
+              $tmp = $content.children(".last.received + article")
+              # 新着が存在しない場合はスクロールを実行するためにレスを探す
+              $tmp = $content.children("article.last") unless $tmp.length is 1
+              $tmp = $content.children("article.read") unless $tmp.length is 1
+              $tmp = $content.children("article:last-child") unless $tmp.length is 1
+              threadContent.scrollTo(+$tmp.find(".num").text(), true, -100) if $tmp.length is 1
           when "surely_new"
             res_num = $view.find("article.received + article").index() + 1
             threadContent.scrollTo(res_num, true) if typeof res_num is "number"
@@ -177,10 +202,12 @@ app.boot "/view/thread.html", ->
             threadContent.scrollTo(res_num, true) if typeof res_num is "number"
 
     app.view_thread._draw($view).catch ->
+      jumpResNum = -1
       return
     .then ->
       if app.config.get("no_history") is "off"
         app.History.add(view_url, document.title, opened_at)
+      jumpResNum = -1
       return
 
   #自動更新


### PR DESCRIPTION
[書込履歴から該当レスへ飛べるようにする](https://github.com/readcrx-2/read.crx-2/issues/126) と、URLに指定されたレス番号へ飛べるようにする機能を追加しました。

- 書込履歴からは無条件にレス番号に飛びます。
- URLのクリック時は、デフォルトの動作を設定画面で指定し、コンテキストメニューからは逆の動作をするようにしました。
- `@href = "javascript:undefined;"`となっていた箇所は、コンテキストメニューの`targetUrlPatterns`が参照することと、該当行を削除しても動作に問題がなかったので削除しました。
