### PR TITLE
Update: npm-scriptにビルド関連のコマンドを追加 ref #292

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,11 @@
     "type": "git",
     "url": "https://github.com/readcrx-2/read.crx-2.git"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "build": "gulp",
+    "clean": "gulp clean",
+    "watch": "gulp watch",
+    "pack": "gulp pack"
+  }
 }


### PR DESCRIPTION
ref #292 

```
$ npm run build
$ npm run clean
$ npm run watch
$ npm run pack
```

でそれぞれ、gulpのタスクを呼び出す用にnpm-scriptsを追加。