### PR TITLE
Update: 携帯・スマホ用のURLをPC用URLに変換して開けるようにする close #302

### DIFF
--- a/src/core/BBSMenu.coffee
+++ b/src/core/BBSMenu.coffee
@@ -14,6 +14,12 @@ class app.BBSMenu
   @_forceReloadFlag: false
 
   ###*
+  @property boardTableCallbacks
+  @type Object|null
+  ###
+  @boardTableCallbacks = null
+
+  ###*
   @method get
   @param {Function} Callback
   @param {Boolean} [ForceReload=false]

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -394,7 +394,7 @@ namespace app {
       }
 
       if (server !== null) {
-        resUrl = mode[1] + "://" + server + ".2ch." + target + "/test/read.cgi/" + mode[4] + "/" + mode[5] + "/";
+        resUrl = `${mode[1]}://${server}.2ch.${target}/test/read.cgi/${mode[4]}/${mode[5]}/`;
       }
       return resUrl;
     }

--- a/src/cs_addlink.coffee
+++ b/src/cs_addlink.coffee
@@ -1,6 +1,9 @@
 regs = [
-  ///^https?://(?!find|info|p2)\w+(?:\.2ch\.net|\.2ch\.sc|\.open2ch\.net)/\w+/(?:index\.html)?(?:#\d+)?$///
-  ///^https?://(?!itest)\w+(?:\.2ch\.net|\.2ch\.sc|\.open2ch\.net|\.bbspink\.com)/test/read\.cgi/\w+/\d+///
+  ///^https?://(?!find|info|p2)\w+(?:\.2ch\.net|\.2ch\.sc|\.open2ch\.net|\.bbspink\.com)/(?:subback/)?\w+/?(?:index\.html)?(?:#\d+)?$///
+  ///^https?://\w+(?:\.2ch\.net|\.2ch\.sc|\.open2ch\.net|\.bbspink\.com)/(?:\w+/)?test/read\.cgi/\w+/\d+/?.*///
+  ///^https?://ula\.2ch\.net/2ch/\w+/[\w+\.]+/\d+/.*///
+  ///^https?://c\.2ch\.net/test/-/\w+/i?(?:\?.+)?///
+  ///^https?://c\.2ch\.net/test/-/\w+/\d+/(?:i|g|\d+)?(?:\?.+)?///
   ///^https?://jbbs\.shitaraba\.net/\w+/\d+/(?:index\.html)?(?:#\d+)?$///
   ///^https?://jbbs\.shitaraba\.net/bbs/read(?:_archive)?\.cgi/\w+/\d+/\d+///
   ///^https?://jbbs\.shitaraba\.net/\w+/\d+/storage/\d+\.html///
@@ -10,12 +13,12 @@ regs = [
 
 open_button_id = "36e5cda5"
 close_button_id = "92a5da13"
+url = chrome.extension.getURL("/view/index.html")
+url += "?q=#{encodeURIComponent(location.href)}"
 
 if (regs.some (a) -> a.test(location.href))
   document.body.addEventListener "mousedown", (e) ->
     if e.target.id is open_button_id
-      url = chrome.extension.getURL("/view/index.html")
-      url += "?q=#{encodeURIComponent(location.href)}"
       a = document.createElement("a")
       a.href = url
       event = new MouseEvent("click", {button: e.button ,ctrlKey: e.ctrlKey, shiftKey: e.shiftKey})

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -265,7 +265,7 @@ class app.view.Index extends app.view.View
     iframe?.contentDocument.C("content")[0].focus()
     return
 
-app.boot "/view/index.html", ->
+app.boot "/view/index.html", ["bbsmenu"], (BBSMenu) ->
   query = app.URL.parseQuery(location.search).get("q")
 
   get_current = new Promise( (resolve, reject) ->
@@ -298,7 +298,12 @@ app.boot "/view/index.html", ->
       if query
         paramResNumFlag = (app.config.get("enable_link_with_res_number") is "on")
         paramResNum = if paramResNumFlag then app.URL.getResNumber(query) else null
-        app.message.send("open", url: query, new_tab: true, param_res_num: paramResNum)
+        # 後ほど実行するためにCallbacksに登録する
+        app.BBSMenu.boardTableCallbacks = new app.Callbacks({persistent: false})
+        app.BBSMenu.boardTableCallbacks.add( ->
+          app.message.send("open", url: query, new_tab: true, param_res_num: paramResNum)
+          return
+        )
 
 app.view_setup_resizer = ->
   MIN_TAB_HEIGHT = 100
@@ -367,6 +372,8 @@ app.view_setup_resizer = ->
 app.main = ->
   urlToIframeInfo = (url) ->
     url = app.URL.fix(url)
+    # 携帯・スマホ用URLの変換
+    url = app.URL.convertUrlFromPhone(url)
     guessResult = app.URL.guessType(url)
     if url is "config"
       src: "/view/config.html"

--- a/src/view/sidemenu.coffee
+++ b/src/view/sidemenu.coffee
@@ -62,8 +62,8 @@ app.boot "/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
         when "title"
           $a.textContent = message.entry.title
 
-  checkNetSc = (url) ->
-    res = {net: false, sc: false}
+  checkBbsmenuParam = (url) ->
+    res = {net: false, sc: false, bbspink: false}
     tmp = ///http://kita.jikkyo.org/cbm/cbm.cgi/([\w\d\.]+)(?:/-all|-live2324)?(?:/=[\d\w=!&$()[\]{}]+)?/bbsmenuk?2?.html///.exec(url)
     if tmp
       param = tmp[1].split(".")
@@ -72,6 +72,8 @@ app.boot "/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
           res.net = true
         else if mode is "sc"
           res.sc = true
+        else if mode in ["p0", "p1"]
+          res.bbspink = true
     return res
 
   #板覧関連
@@ -80,11 +82,12 @@ app.boot "/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
       $view.addClass("loading")
       # 表示用板一覧の取得
       BBSMenu.get (res) ->
-        # 2ch.netと2ch.scの存在確認
-        modeFlag = checkNetSc(res.url)
+        # bbsmenuパラメータの確認
+        modeFlag = checkBbsmenuParam(res.url)
         menuUpdate = (res.url is app.config.get("bbsmenu"))
         boardNet = []
         boardSc = []
+        boardBbspink = []
 
         if menuUpdate
           for dom in $view.$$("h3:not(:first-of-type), ul:not(:first-of-type)")
@@ -110,21 +113,24 @@ app.boot "/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
                 boardNet.push(board)
               if modeFlag.sc and /// https?://\w+\.2ch\.sc/\w+/.*? ///.test(board.url)
                 boardSc.push(board)
+              if modeFlag.bbspink and /// https?://\w+\.bbspink\.com/\w+/.*? ///.test(board.url)
+                boardBbspink.push(board)
             frag.addLast($ul)
 
-        # 2ch.netと2ch.scの板・サーバー情報の登録
-        app.URL.pushBoardToServerInfo(boardNet, boardSc)
-        boardNet = []   # メモリ解放用
-        boardSc = []    #     〃
+        # 2ch.netと2ch.sc及びbbspinkの板・サーバー情報の登録
+        app.URL.pushBoardToServerInfo(boardNet, boardSc, boardBbspink)
+        boardNet = []     # メモリ解放用
+        boardSc = []      # 　　〃
+        boardBbspink = [] # 　　〃
 
         if menuUpdate
           document.body.addLast(frag)
           accordion.update()
 
-        # 2ch.netと2ch.scの切替用情報の取得
+        # 2ch.netと2ch.sc及びbbspinkのサーバー情報の取得
         if (
           res.url is app.config.get("bbsmenu") and
-          (!modeFlag.net or !modeFlag.sc)
+          !(modeFlag.net and modeFlag.sc and modeFlag.bbspink)
         )
           loopCount = 0
           intervalID = setInterval( ->
@@ -133,13 +139,12 @@ app.boot "/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
             # メニューの更新が終了するまで待機
             unless $view.hasClass("loading")
               clearInterval(intervalID)
-              # 2ch.netと2ch.scの板情報の追加取得
-              if !modeFlag.net and !modeFlag.sc
-                param = "20.sc"
-              else if !modeFlag.net
-                param = "20.99"
-              else
-                param = "sc.99"
+              # bbsmenuパラメータの編集
+              param = ""
+              param += "20." unless modeFlag.net
+              param += "sc." unless modeFlag.sc
+              param += "p0." unless modeFlag.bbspink
+              param += "99"
               otherUrl = "http://kita.jikkyo.org/cbm/cbm.cgi/#{param}/-all/bbsmenu.html"
               BBSMenu.get((res) ->
                 # 表示用一覧取得時のコールバックが実行されるので何もしない
@@ -147,6 +152,9 @@ app.boot "/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
               , false, otherUrl)
             return
           , 1000)
+        else if BBSMenu.boardTableCallbacks
+          BBSMenu.boardTableCallbacks.call()
+          BBSMenu.boardTableCallbacks = null
 
         $view.removeClass("loading")
         return

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -539,12 +539,14 @@ app.boot "/view/thread.html", ->
   $view.on("mouseenter", (e) ->
     target = e.target
     return unless target.matches(".message a:not(.anchor)")
-    tmp = app.URL.guessType(target.href)
+    # 携帯・スマホ用URLをPC用URLに変換
+    url = app.URL.convertUrlFromPhone(target.href)
+    tmp = app.URL.guessType(url)
     if tmp.type is "board"
-      board_url = app.URL.fix(target.href)
+      board_url = app.URL.fix(url)
       after = ""
     else if tmp.type is "thread"
-      board_url = app.URL.threadToBoard(target.href)
+      board_url = app.URL.threadToBoard(url)
       after = "のスレ"
     else
       return


### PR DESCRIPTION
携帯・スマホ・ULA版のURLをPC用のURLに変換して開けるようにしました。

`cs_addlink.coffee`内の`getURL()`がエラーになることがあります。
正規表現のちょっとした違いや比較する文字列のちょっとした違いによって発生したりしなかったりと原因がわからないため、`getURL()`の実行を評価前に移動しました。