### PR TITLE
Fix: 設定の「関連リンク」のリンク文字列がひとつなぎに表示される close #340

### DIFF
--- a/src/view/config.scss
+++ b/src/view/config.scss
@@ -104,6 +104,9 @@ section button {
   padding: 0;
   > li {
     display: inline-block;
+    &:not(:first-child) {
+      margin-left: 5px;
+    }
   }
 }
 


### PR DESCRIPTION
見落としがあったようなので、修正しました。