### PR TITLE
ブックマーク・スレッド一覧及び設定画面の修正

### DIFF
--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -179,6 +179,9 @@ class UI.ThreadList
         tr = $table.$("tr[data-href=\"#{msg.read_state.url}\"]")
         if tr
           res = tr.$(selector.res)
+          if +res.textContent < msg.read_state.received
+            res.textContent = msg.read_state.received
+            tr.addClass("updated")
           unread = tr.$(selector.unread)
           unreadCount = Math.max(+res.textContent - msg.read_state.read, 0)
           unread.textContent = unreadCount or ""

--- a/src/view/board.coffee
+++ b/src/view/board.coffee
@@ -82,7 +82,7 @@ app.boot "/view/board.html", ->
     $view.addClass("loading")
     app.message.send("request_update_read_state", {board_url: url})
 
-    app.defer( ->
+    setTimeout( ->
       get_read_state_promise = app.ReadState.getByBoard(url)
 
       board_get_promise = new Promise( (resolve, reject) ->
@@ -160,7 +160,7 @@ app.boot "/view/board.html", ->
           setTimeout((-> $button.removeClass("disabled")), 1000 * 5)
           return
       return
-    )
+    , 150)
     return
 
   $view.on "request_reload", (e) ->

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -542,11 +542,11 @@ app.boot "/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
               when "radio"
                 $key.value = value
                 $key.dispatchEvent(new Event("change"))
-              else
-                $keyTextArea = $view.$("textarea[name=\"#{key}\"]")
-                if $keyTextArea?
-                  $keyTextArea.value = value
-                  $key.dispatchEvent(new Event("input"))
+          else
+            $keyTextArea = $view.$("textarea[name=\"#{key}\"]")
+            if $keyTextArea?
+              $keyTextArea.value = value
+              $keyTextArea.dispatchEvent(new Event("input"))
          #config_theme_idは「テーマなし」の場合があるので特例化
          else
            if value is "none"

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -1062,6 +1062,7 @@ app.view_thread._read_state_manager = ($view) ->
     # 2回目の処理
     # 画像のロードにより位置がずれることがあるので初回処理時の内容を使用する
     if readStateAttached
+      tmpReadState = {read: null, received: null, url: view_url}
       if attachedReadState.last > 0
         $content.C("last")[0]?.removeClass("last")
         $content.child()[attachedReadState.last - 1]?.addClass("last")
@@ -1069,12 +1070,16 @@ app.view_thread._read_state_manager = ($view) ->
       if attachedReadState.read > 0
         $content.C("read")[0]?.removeClass("read")
         $content.child()[attachedReadState.read - 1]?.addClass("read")
+        tmpReadState.read = attachedReadState.read
       if attachedReadState.received > 0
         $content.C("received")[0]?.removeClass("received")
         $content.child()[attachedReadState.received - 1]?.addClass("received")
+        tmpReadState.received = attachedReadState.received
       readStateAttached = false
       requestReloadFlag = false
       $view.dispatchEvent(new Event("read_state_attached"))
+      if tmpReadState.read and tmpReadState.received
+        app.message.send("read_state_updated", {board_url, read_state: tmpReadState})
       return
     # 初回の処理
     get_read_state.then ({read_state, read_state_updated}) ->
@@ -1106,6 +1111,8 @@ app.view_thread._read_state_manager = ($view) ->
       requestReloadFlag = false
 
       $view.dispatchEvent(new Event("read_state_attached"))
+      if attachedReadState.read > 0 and attachedReadState.received > 0
+        app.message.send("read_state_updated", {board_url, read_state})
     return
 
   get_read_state.then ({read_state, read_state_updated}) ->


### PR DESCRIPTION
- 勢いの速いスレなどで、ブックマークとスレッド一覧のレス数・未読数が実際と異なることがある
- 設定情報のインポートで、TextAreaへの取り込みが行われていない

以上2点の修正をしました。