### PR TITLE
Update: 現在のブックマーク保存フォルダを表示するように+α

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   },
   "devDependencies": {
     "ShortQuery.js": "S--Minecraft/ShortQuery.js#0.3.1",
-    "coffee-script": "1.12.6",
+    "coffee-script": "1.12.7",
     "crx": "^3.2.1",
-    "fs-extra": "^3.0.1",
+    "fs-extra": "^4.0.0",
     "gulp": "^3.9.1",
     "gulp-changed": "^3.1.0",
     "gulp-coffee": "^2.3.4",
@@ -26,7 +26,7 @@
     "run-sequence": "^1.2.2",
     "sharp": "^0.18.1",
     "to-ico": "^1.1.4",
-    "typescript": "2.4.0"
+    "typescript": "2.4.2"
   },
   "repository": {
     "type": "git",

--- a/src/ui/MediaContainer.coffee
+++ b/src/ui/MediaContainer.coffee
@@ -1,0 +1,141 @@
+###*
+@namespace UI
+@class MediaContainer
+@constructor
+@param {Element} container
+###
+class UI.MediaContainer
+
+  constructor: (@container) ->
+    ###*
+    @property _videoPlayTime
+    @type Number
+    @private
+    ###
+    @_videoPlayTime = 0
+
+    @setVideoEvents()
+    @setHoverEvents()
+    return
+
+  ###*
+  @method setHoverEvents
+  ###
+  setHoverEvents: ->
+    isImageOn = app.config.get("hover_zoom_image") is "on"
+    isVideoOn = app.config.get("hover_zoom_video") is "on"
+    imageRatio = app.config.get("zoom_ratio_image") + "%"
+    videoRatio = app.config.get("zoom_ratio_video") + "%"
+
+    @container.on("mouseenter", ({target}) ->
+      return unless target.matches(".thumbnail > a > img.image, .thumbnail > video")
+      if isImageOn and target.tagName is "IMG"
+        target.closest(".thumbnail").addClass("zoom")
+        target.style.zoom = imageRatio
+      else if isVideoOn and target.tagName is "VIDEO"
+        target.closest(".thumbnail").addClass("zoom")
+        target.style.zoom = videoRatio
+      return
+    , true)
+
+    @container.on("mouseleave", ({target}) ->
+      return unless (
+        target.matches(".thumbnail > a > img.image, .thumbnail > video") and
+        (
+          (isImageOn and target.tagName is "IMG") or
+          (isVideoOn and target.tagName is "VIDEO")
+        )
+      )
+      target.closest(".thumbnail").removeClass("zoom")
+      target.style.zoom = "normal"
+      return
+    , true)
+    return
+
+  ###*
+  @method setVideoEvents
+  ###
+  setVideoEvents: ->
+    # VIDEOの再生/一時停止
+    @container.on("click", ({target}) ->
+      return unless target.matches(".thumbnail > video")
+      target.preload = "auto" if target.preload is "metadata"
+      if target.paused
+        target.play()
+      else
+        target.pause()
+      return
+    )
+
+    # VIDEO再生中はマウスポインタを消す
+    @container.on("mouseenter", ({target}) =>
+      return unless target.matches(".thumbnail > video")
+
+      func = ({type}) =>
+        @_controlVideoCursor(target, type)
+        return
+
+      target.on("play", func)
+      target.on("timeupdate", func)
+      target.on("pause", func)
+      target.on("ended", func)
+      return
+    , true)
+
+    # マウスポインタのリセット
+    @container.on("mousemove", ({target, type}) =>
+      return unless target.matches(".thumbnail > video")
+      @_controlVideoCursor(target, type)
+      return
+    )
+    return
+
+  ###*
+  @method _setImageBlurOne
+  @param {Element} thumbnail
+  @param {Boolean} blurMode
+  @private
+  ###
+  _setImageBlurOne: (thumbnail, blurMode) ->
+    media = thumbnail.$("a > img.image, video")
+    if blurMode
+      v = app.config.get("image_blur_length")
+      thumbnail.addClass("image_blur")
+      media.style.WebkitFilter = "blur(#{v}px)"
+    else
+      thumbnail.removeClass("image_blur")
+      media.style.WebkitFilter = "none"
+    return
+
+  ###*
+  @method setImageBlur
+  @param {Element} res
+  @param {Boolean} blurMode
+  ###
+  setImageBlur: (res, blurMode) ->
+    for thumb in res.$$(".thumbnail[media-type='image'], .thumbnail[media-type='video']")
+      @_setImageBlurOne(thumb, blurMode)
+    return
+
+  ###*
+  @method _controlVideoCursor
+  @param {Element} ele
+  @param {String} act
+  @private
+  ###
+  _controlVideoCursor: (ele, act) ->
+    switch act
+      when "play"
+        @_videoPlayTime = Date.now()
+      when "timeupdate"
+        return if ele.style.cursor is "none"
+        if Date.now() - @_videoPlayTime > 2000
+          ele.style.cursor = "none"
+      when "pause", "ended"
+        ele.style.cursor = "auto"
+        @_videoPlayTime = 0
+      when "mousemove"
+        return if @_videoPlayTime is 0
+        ele.style.cursor = "auto"
+        @_videoPlayTime = Date.now()
+    return

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -193,16 +193,23 @@ namespace UI {
 
     add (
       url: string,
-      param: {title?: string; selected?: boolean; locked?: boolean; lazy?: boolean; restore?: boolean} =
-        {title: undefined, selected: undefined, locked: undefined, lazy: undefined, restore: undefined}
+      {
+        title = null,
+        selected = true,
+        locked = false,
+        lazy = false,
+        restore = false
+      }: Partial<{
+        title: string|null,
+        selected: boolean,
+        locked: boolean,
+        lazy: boolean,
+        restore: boolean
+      }> = {}
     ): string {
       var tabId: string;
 
-      param.title = param.title === undefined ? url : param.title;
-      param.selected = param.selected === undefined ? true : param.selected;
-      param.locked = param.locked === undefined ? false : param.locked;
-      param.lazy = param.lazy === undefined ? false : param.lazy;
-      param.restore = param.restore === undefined ? false : param.restore;
+      title = title === null ? url : title;
 
       tabId = Tab.genId();
 
@@ -213,7 +220,7 @@ namespace UI {
 
       // 既存のタブが一つも無い場合、強制的にselectedオン
       if (!this.$element.$(".tab_tabbar > li")) {
-        param.selected = true;
+        selected = true;
       }
 
       var $li = $__("li");
@@ -227,26 +234,26 @@ namespace UI {
       this.$element.$(".tab_tabbar").addLast($li);
 
       var $iframe = $__("iframe");
-      $iframe.src = param.lazy ? "/view/empty.html" : url;
+      $iframe.src = lazy ? "/view/empty.html" : url;
       $iframe.addClass("tab_content");
       $iframe.dataset.tabid = tabId;
       this.$element.$(".tab_container").addLast($iframe);
 
-      this.update(tabId, {title: param.title, selected: param.selected, locked: param.locked});
+      this.update(tabId, {title, selected, locked});
 
       return tabId;
     }
 
     update (
       tabId: string,
-      param: {
-        url?: string;
-        title?: string;
-        selected?: boolean;
-        locked?: boolean;
-        restore?: boolean;
-        _internal?: boolean;
-      }
+      param: Partial<{
+        url: string,
+        title: string,
+        selected: boolean,
+        locked: boolean,
+        restore: boolean,
+        _internal: boolean
+      }>
     ): void {
       var history, $tmptab, $iframe, tmp;
 

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -942,22 +942,6 @@ class UI.ThreadContent
     )
 
   ###*
-  @method setImageBlur
-  @param {Element} thumbnail
-  @param {Boolean} blurMode
-  ###
-  setImageBlur: (thumbnail, blurMode) ->
-    media = thumbnail.$("a > img.image, video")
-    if blurMode
-      v = app.config.get("image_blur_length")
-      thumbnail.addClass("image_blur")
-      media.style.WebkitFilter = "blur(#{v}px)"
-    else
-      thumbnail.removeClass("image_blur")
-      media.style.WebkitFilter = "none"
-    return
-
-  ###*
   @method addClassWithOrg
   @param {Element} $res
   @param {String} className

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -965,7 +965,7 @@ class UI.ThreadContent
   addClassWithOrg: ($res, className) ->
     $res.addClass(className)
     resnum = parseInt($res.C("num")[0].textContent)
-    @container.child()[resnum-1].addClass("written")
+    @container.child()[resnum-1].addClass(className)
     return
 
   ###*
@@ -974,9 +974,9 @@ class UI.ThreadContent
   @param {String} className
   ###
   removeClassWithOrg: ($res, className) ->
-    $res.removeClass("written")
+    $res.removeClass(className)
     resnum = parseInt($res.C("num")[0].textContent)
-    @container.child()[resnum-1].removeClass("written")
+    @container.child()[resnum-1].removeClass(className)
     return
 
   ###*

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -440,9 +440,22 @@ app.boot "/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
       return
     return
 
-  #ブックマークフォルダ変更ボタン
-  $view.C("bookmark_source_change")[0].on "click", ->
-    app.message.send("open", url: "bookmark_source_selector")
+  do ->
+    #ブックマークフォルダ変更ボタン
+    $view.C("bookmark_source_change")[0].on "click", ->
+      app.message.send("open", url: "bookmark_source_selector")
+      return
+
+    #ブックマークフォルダ表示
+    do updateName = ->
+      chrome.bookmarks.get(app.config.get("bookmark_id"), (res) ->
+        $$.I("bookmark_source_name").textContent = res[0].title
+        return
+      )
+    app.message.addListener("config_updated", (message) ->
+      updateName() if message.key is "bookmark_id"
+      return
+    )
     return
 
   #ブックマークインポートボタン

--- a/src/view/config.pug
+++ b/src/view/config.pug
@@ -452,6 +452,10 @@ html.view.view_config(data-app-version=version)
         h2 その他
         div
           button.bookmark_source_change ブックマークのフォルダを変更する
+          span
+            |(現在のフォルダ:
+            span#bookmark_source_name
+            |)
 
           br
 

--- a/src/view/history.coffee
+++ b/src/view/history.coffee
@@ -18,7 +18,7 @@ app.boot "/view/history.html", ->
   loadAddCount = 0
   isLoadedEnd = false
 
-  load = ({ignoreLoading = false, add = false} = {ignoreLoading: false, add: false}) ->
+  load = ({ignoreLoading = false, add = false} = {}) ->
     return if $view.hasClass("loading")
     return if $view.C("button_reload")[0].hasClass("disabled") and not (ignoreLoading or add)
     return if add and isLoadedEnd

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -663,6 +663,7 @@ class app.view.TabContentView extends app.view.PaneContentView
     auto_load = =>
       second = parseInt(app.config.get("auto_load_second#{cfgName}"))
       if second >= minSeconds
+        @$element.addClass("autoload")
         $button.removeClass("hidden")
         if @$element.hasClass("view_bookmark")
           return setInterval( =>
@@ -680,6 +681,7 @@ class app.view.TabContentView extends app.view.PaneContentView
             return
           , second)
       else
+        @$element.removeClass("autoload")
         $button.addClass("hidden")
       return
 
@@ -693,6 +695,7 @@ class app.view.TabContentView extends app.view.PaneContentView
     )
 
     $button.on("click", ->
+      @$element.togggleClass("autoload_pause")
       $button.toggleClass("pause")
       if $button.hasClass("pause")
         clearInterval(auto_load_interval)

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -48,12 +48,12 @@ app.boot "/view/thread.html", ->
     alert("不正な引数です")
     return
   view_url = app.URL.fix(view_url)
+
   jumpResNum = -1
   iframe = parent.$$.$("iframe[data-url=\"#{view_url}\"]")
   if iframe
     jumpResNum = +iframe.dataset.writtenResNum
-    if jumpResNum < 1
-      jumpResNum = +iframe.dataset.paramResNum
+    jumpResNum = +iframe.dataset.paramResNum if jumpResNum < 1
 
   $view = document.documentElement
   $view.dataset.url = view_url
@@ -135,28 +135,27 @@ app.boot "/view/thread.html", ->
       if ex?.param_res_num? and jumpResNum < 1
         jumpResNum = +ex.param_res_num
       if (
-        $view.hasClass("loading") or
-        $view.C("button_reload")[0].hasClass("disabled")
+        (
+          $view.hasClass("loading") or
+          $view.C("button_reload")[0].hasClass("disabled")
+        ) and
+        jumpResNum > 0
       )
-        if jumpResNum > 0
-          threadContent.scrollTo(jumpResNum, true, -60)
-          threadContent.select(jumpResNum, true)
-          jumpResNum = -1
+        threadContent.scrollTo(jumpResNum, true, -60)
+        threadContent.select(jumpResNum, true)
+        jumpResNum = -1
         return
 
       app.view_thread._draw($view, ex?.force_update, (thread) ->
-        if ex?.mes? and app.config.get("no_writehistory") is "off"
-          i = thread.res.length - 1
-          while i >= 0
-            if ex.mes.replace(/\s/g, "") is app.util.decode_char_reference(app.util.stripTags(thread.res[i].message)).replace(/\s/g, "")
-              date = threadContent.stringToDate(thread.res[i].other)
-              name = app.util.decode_char_reference(thread.res[i].name)
-              mail = app.util.decode_char_reference(thread.res[i].mail)
-              if date?
-                app.WriteHistory.add(view_url, i+1, document.title, name, mail, ex.name, ex.mail, ex.mes, date.valueOf())
-              break
-            i--
-          jumpResNum = -1
+        return unless ex?.mes? and app.config.get("no_writehistory") is "off"
+        postMes = ex.mes.replace(/\s/g, "")
+        for t, i in thread.res by -1 when postMes is app.util.decode_char_reference(app.util.stripTags(t.message)).replace(/\s/g, "")
+          date = threadContent.stringToDate(t.other)
+          name = app.util.decode_char_reference(t.name)
+          mail = app.util.decode_char_reference(t.mail)
+          app.WriteHistory.add(view_url, i+1, document.title, name, mail, ex.name, ex.mail, ex.mes, date.valueOf()) if date?
+          break
+        jumpResNum = -1
         return
       )
     return
@@ -180,7 +179,7 @@ app.boot "/view/thread.html", ->
         lastNum = +dom.C("num")[0].textContent
         break
       # 指定レス番号へ
-      if jumpResNum > 0 and jumpResNum <= lastNum
+      if 0 < jumpResNum <= lastNum
         threadContent.scrollTo(jumpResNum, true, -60)
         threadContent.select(jumpResNum, true)
       # 最終既読位置へ
@@ -194,12 +193,13 @@ app.boot "/view/thread.html", ->
 
       #二度目以降のread_state_attached時
       $view.on "read_state_attached", ->
+        move_mode = "new"
         #通常時と自動更新有効時で、更新後のスクロールの動作を変更する
-        move_mode = if $view.hasClass("autoload") and not $view.hasClass("autoload_pause") then app.config.get("auto_load_move") else "new"
+        move_mode = app.config.get("auto_load_move") if $view.hasClass("autoload") and not $view.hasClass("autoload_pause")
         switch move_mode
           when "new"
             lastNum = +$content.$(":scope > article:last-child")?.C("num")[0].textContent
-            if jumpResNum > 0 and jumpResNum <= lastNum
+            if 0 < jumpResNum <= lastNum
               threadContent.scrollTo(jumpResNum, true, -60)
               threadContent.select(jumpResNum, true)
             else
@@ -229,8 +229,7 @@ app.boot "/view/thread.html", ->
       jumpResNum = -1
       return
     .then ->
-      if app.config.get("no_history") is "off"
-        app.History.add(view_url, document.title, opened_at)
+      app.History.add(view_url, document.title, opened_at) unless app.config.get("no_history") is "on"
       jumpResNum = -1
       return
 
@@ -262,13 +261,11 @@ app.boot "/view/thread.html", ->
         $menu.C("search_selection")[0].remove()
       return
 
+    $toggleAaMode = $menu.C("toggle_aa_mode")[0]
     if $article.parent().hasClass("config_use_aa_font")
-      if $article.hasClass("aa")
-        $menu.C("toggle_aa_mode")[0].textContent = "AA表示モードを解除"
-      else
-        $menu.C("toggle_aa_mode")[0].textContent = "AA表示モードに変更"
+      $toggleAaMode = if $article.hasClass("aa") then "AA表示モードを解除" else "AA表示モードに変更"
     else
-      $menu.C("toggle_aa_mode")[0].remove()
+      $toggleAaMode.remove()
 
     unless $article.dataset.id?
       $menu.C("copy_id")[0].remove()
@@ -313,8 +310,8 @@ app.boot "/view/thread.html", ->
   $view.on("contextmenu", onHeaderMenu)
 
   #レスメニュー表示(内容上)
-  $view.on "contextmenu", (e) ->
-    return unless e.target.matches("article > .message")
+  $view.on "contextmenu", ({target}) ->
+    return unless target.matches("article > .message")
     # 選択範囲をNG登録
     app.contextMenus.update("add_selection_to_ngwords", {
       onclick: (info, tab) ->
@@ -326,8 +323,7 @@ app.boot "/view/thread.html", ->
     return
 
   #レスメニュー項目クリック
-  $view.on "click", (e) ->
-    target = e.target
+  $view.on "click", ({target}) ->
     return unless target.matches(".res_menu > li")
     $res = target.closest("article")
 
@@ -465,22 +461,21 @@ app.boot "/view/thread.html", ->
     return if target.hasClass("open_in_rcrx")
 
     #read.crxで開けるURLかどうかを判定
-    flg = false
+    flg = do ->
+      #スレのURLはほぼ確実に判定できるので、そのままok
+      return true if tmp.type is "thread"
+      #2chタイプ以外の板urlもほぼ確実に判定できる
+      return true if tmp.type is "board" and tmp.bbsType isnt "2ch"
+      #2chタイプの板は誤爆率が高いので、もう少し細かく判定する
+      if tmp.type is "board" and tmp.bbsType is "2ch"
+        #2ch自体の場合の判断はguess_typeを信じて板判定
+        return true if app.URL.tsld(target_url) is "2ch.net"
+        #ブックマークされている場合も板として判定
+        return true if app.bookmark.get(app.URL.fix(target_url))
+      return false
+
     tmp = app.URL.guessType(target_url)
-    #スレのURLはほぼ確実に判定できるので、そのままok
-    if tmp.type is "thread"
-      flg = true
-    #2chタイプ以外の板urlもほぼ確実に判定できる
-    else if tmp.type is "board" and tmp.bbsType isnt "2ch"
-      flg = true
-    #2chタイプの板は誤爆率が高いので、もう少し細かく判定する
-    else if tmp.type is "board" and tmp.bbsType is "2ch"
-      #2ch自体の場合の判断はguess_typeを信じて板判定
-      if app.URL.tsld(target_url) is "2ch.net"
-        flg = true
-      #ブックマークされている場合も板として判定
-      else if app.bookmark.get(app.URL.fix(target_url))
-        flg = true
+
     #read.crxで開ける板だった場合は.open_in_rcrxを付与して再度クリックイベント送出
     if flg
       e.preventDefault()
@@ -504,14 +499,15 @@ app.boot "/view/thread.html", ->
     # 携帯・スマホ用URLをPC用URLに変換
     url = app.URL.convertUrlFromPhone(target.href)
     tmp = app.URL.guessType(url)
-    if tmp.type is "board"
-      board_url = app.URL.fix(url)
-      after = ""
-    else if tmp.type is "thread"
-      board_url = app.URL.threadToBoard(url)
-      after = "のスレ"
-    else
-      return
+    switch tmp.type
+      when "board"
+        board_url = app.URL.fix(url)
+        after = ""
+      when "thread"
+        board_url = app.URL.threadToBoard(url)
+        after = "のスレ"
+      else
+        return
 
     app.BoardTitleSolver.ask(board_url).then (title) =>
       popup_helper target, e, =>
@@ -552,7 +548,14 @@ app.boot "/view/thread.html", ->
       $popup.addClass("popup_id")
       $article = target.closest("article")
 
-      if $article.parent().hasClass("popup_id") and ($article.dataset.id is id or $article.dataset.slip is slip or $article.dataset.trip is trip)
+      if (
+        $article.parent().hasClass("popup_id") and
+        (
+          $article.dataset.id is id or
+          $article.dataset.slip is slip or
+          $article.dataset.trip is trip
+        )
+      )
         $div = $__("div")
         $div.textContent = "現在ポップアップしているIP/ID/SLIP/トリップです"
         $div.addClass("popup_disabled")
@@ -594,16 +597,15 @@ app.boot "/view/thread.html", ->
   , true)
 
   #何もないところをダブルクリックすると更新する
-  $view.on "dblclick", (e) ->
+  $view.on "dblclick", ({target}) ->
     return if app.config.get("dblclick_reload") is "off"
-    return unless e.target.hasClass("message")
-    return if e.target.tagName is "A" or e.target.hasClass("thumbnail")
+    return unless target.hasClass("message")
+    return if target.tagName is "A" or target.hasClass("thumbnail")
     $view.dispatchEvent(new Event("request_reload"))
     return
 
   # VIDEOの再生/一時停止
-  $view.on "click", (e) ->
-    target = e.target
+  $view.on "click", ({target}) ->
     return unless target.matches(".thumbnail > video")
     target.preload = "auto" if target.preload is "metadata"
     if target.paused
@@ -613,8 +615,7 @@ app.boot "/view/thread.html", ->
     return
 
   # VIDEO再生中はマウスポインタを消す
-  $view.on("mouseenter", (e) ->
-    target = e.target
+  $view.on("mouseenter", ({target}) ->
     return unless target.matches(".thumbnail > video")
     target.on("play", (evt) ->
       app.view_thread._controlVideoCursor(target, evt.type)
@@ -667,8 +668,7 @@ app.boot "/view/thread.html", ->
   , true)
 
   # リンクのコンテキストメニュー
-  $view.on "contextmenu", (e) ->
-    target = e.target
+  $view.on "contextmenu", ({target}) ->
     return unless target.matches(".message > a")
     # リンクアドレスをNG登録
     enableFlg = !(target.hasClass("anchor") or target.hasClass("anchor_id"))
@@ -696,8 +696,7 @@ app.boot "/view/thread.html", ->
     return
 
   # 画像のコンテキストメニュー
-  $view.on "contextmenu", (e) ->
-    target = e.target
+  $view.on "contextmenu", ({target}) ->
     return unless target.matches("img, video, audio")
     switch target.tagName
       when "IMG"
@@ -745,11 +744,9 @@ app.boot "/view/thread.html", ->
           $jump_panel.$(panel_item_selector).style.display = "none"
       return
 
-    $jump_panel.on "click", (e) ->
-      $target = e.target
-
+    $jump_panel.on "click", ({target}) ->
       for key, val of jump_hoge
-        if $target.matches(key)
+        if target.matches(key)
           selector = val
           offset = if key in [".jump_not_read", ".jump_new"] then -100 else 0
           break
@@ -818,8 +815,8 @@ app.boot "/view/thread.html", ->
       $content.dispatchEvent(new Event("searchfinish"))
       return
 
-    $searchbox.on "keyup", (e) ->
-      if e.which is 27 #Esc
+    $searchbox.on "keyup", ({which}) ->
+      if which is 27 #Esc
         if @value isnt ""
           @value = ""
           @dispatchEvent(new Event("input"))
@@ -924,16 +921,16 @@ app.boot "/view/thread.html", ->
     return
 
   # サムネイルロード時の追加処理
-  $view.on "lazyload-load", (e) ->
-    target = e.target.closest(".thumbnail > a > img.image, .thumbnail > video")
+  $view.on "lazyload-load", ({target}) ->
+    target = target.closest(".thumbnail > a > img.image, .thumbnail > video")
     return unless target?
     # マウスオーバーによるズームの設定
     app.view_thread._setupHoverZoom(target)
     return
 
   # 逆スクロール時の処理
-  $view.on "lazyload-load-reverse", (e) ->
-    target = e.target.closest(".thumbnail > a > img.image, .thumbnail > video")
+  $view.on "lazyload-load-reverse", ({target}) ->
+    target = target.closest(".thumbnail > a > img.image, .thumbnail > video")
     return unless target?
     # マウスオーバーによるズームの設定
     app.view_thread._setupHoverZoom(target)

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -195,7 +195,7 @@ app.boot "/view/thread.html", ->
       #二度目以降のread_state_attached時
       $view.on "read_state_attached", ->
         #通常時と自動更新有効時で、更新後のスクロールの動作を変更する
-        move_mode = if parseInt(app.config.get("auto_load_second")) >= 5000 then app.config.get("auto_load_move") else "new"
+        move_mode = if $view.hasClass("autoload") and not $view.hasClass("autoload_pause") then app.config.get("auto_load_move") else "new"
         switch move_mode
           when "new"
             lastNum = +$content.$(":scope > article:last-child")?.C("num")[0].textContent

--- a/src/view/writehistory.coffee
+++ b/src/view/writehistory.coffee
@@ -17,7 +17,7 @@ app.boot "/view/writehistory.html", ->
   loadAddCount = 0
   isLoadedEnd = false
 
-  load = ({add = false} = {add: false}) ->
+  load = ({add = false} = {}) ->
     return if $view.hasClass("loading")
     return if $view.C("button_reload")[0].hasClass("disabled") and not add
     return if add and isLoadedEnd

--- a/src/view/writehistory.coffee
+++ b/src/view/writehistory.coffee
@@ -17,7 +17,7 @@ app.boot "/view/writehistory.html", ->
   loadAddCount = 0
   isLoadedEnd = false
 
-  load = (add = false) ->
+  load = ({add = false} = {add: false}) ->
     return if $view.hasClass("loading")
     return if $view.C("button_reload")[0].hasClass("disabled") and not add
     return if add and isLoadedEnd
@@ -61,7 +61,7 @@ app.boot "/view/writehistory.html", ->
     if scrollHeight - scrollPosition < 100
       return if isInLoadArea
       isInLoadArea = true
-      load(true)
+      load(add: true)
     else
       isInLoadArea = false
   , passive: true)


### PR DESCRIPTION
Update: 現在のブックマーク保存フォルダを表示するように refs #162
Update: CoffeeScript 1.12.7, TypeScript 2.4.2, fs-extra 4.0.0

Fix: 書込履歴の再読み込みができないのを修正 close #365 
Fix: 自動更新一時停止中に更新するときに通常更新時の挙動をしていなかったのを修正
Fix: 変数のところに定数が誤って入っているのを修正

Fix: リファクタリング
 - Tab.ts: `Partial<>`で書くように+デフォルト引数の整理
 - thread.coffee: `a < x < b`の書き方
 - thread.coffee: `while i--` -> `for by -1`
 - thread.coffee: `(e)`,`e.target` -> `({target})`
 - 画像/動画関連処理をUI.MediaContainerに
    - MediaContainer.coffee: 作成
    - LazyLoad.ts: 関数の順序を変更
    - 画像/動画のホバーの拡大のイベントをdelegateで
       - LazyLoad.ts: それに伴い`lazyload-load`, `lazyload-load-reverse`の廃止
       - LazyLoad.ts: `update()`の整理
    - ThreadContent.coffee: `setImageBlur()`をMediaContainerに
    - thread.coffee: `_setupHoverZoom()`の廃止
    - thread.coffee: videoの再生やマウスポインタ関連イベントをMediaContainerに
    - history.coffee, writehistory.coffee: `({～} = {～})` -> `({～} = {})`