### PR TITLE
Fix: thread.coffee/ThreadContent.coffeeのリファクタリング

### DIFF
--- a/src/core/Bookmark.CompatibilityLayer.ts
+++ b/src/core/Bookmark.CompatibilityLayer.ts
@@ -155,9 +155,8 @@ namespace app.Bookmark {
           this.cbel.update(entry, undefined, (res) => {
             res ? resolve() : reject();
           });
-        }
-        else {
-          reject();
+        } else {
+          resolve();
         }
       });
     }

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -309,9 +309,11 @@ class UI.ThreadContent
   ###*
   @method select
   @param {Element | Number} target
-  @param {bool} [preventScroll = false]
+  @param {Boolean} [preventScroll = false]
+  @param {Boolean} [animate = false]
+  @param {Number} [offset = 0]
   ###
-  select: (target, preventScroll = false) ->
+  select: (target, preventScroll = false, animate = false, offset = 0) ->
     @container.$("article.selected")?.removeClass("selected")
 
     if typeof target is "number"
@@ -321,7 +323,7 @@ class UI.ThreadContent
 
     target.addClass("selected")
     if not preventScroll
-      @scrollTo(+target.$(".num").textContent)
+      @scrollTo(+target.$(".num").textContent, animate, offset)
     return
 
   ###*

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -103,7 +103,7 @@ class UI.ThreadContent
 
   ###*
   @method _loadNearlyImages
-  @param {Number}
+  @param {Number} resNum
   @param {Number} [offset=0]
   @return {Boolean} loadFlag
   ###
@@ -171,18 +171,22 @@ class UI.ThreadContent
 
   ###*
   @method scrollTo
-  @param {Number} resNum
+  @param {Element | Number} target
   @param {Boolean} [animate=false]
   @param {Number} [offset=0]
   @param {Boolean} [rerun=false]
   ###
-  scrollTo: (resNum, animate = false, offset = 0, rerun = false) ->
+  scrollTo: (target, animate = false, offset = 0, rerun = false) ->
+    if typeof target is "number"
+      resNum = target
+    else
+      resNum = +target.C("num")[0].textContent
     @_lastScrollInfo.resNum = resNum
     @_lastScrollInfo.animate = animate
     @_lastScrollInfo.offset = offset
     loadFlag = false
 
-    target = @container.child()[resNum - 1]
+    target = @container.children[resNum - 1]
 
     # 検索中で、ターゲットが非ヒット項目で非表示の場合、スクロールを中断
     if target and @container.hasClass("searching") and not target.hasClass("search_hit")
@@ -323,7 +327,7 @@ class UI.ThreadContent
 
     target.addClass("selected")
     if not preventScroll
-      @scrollTo(+target.$(".num").textContent, animate, offset)
+      @scrollTo(target, animate, offset)
     return
 
   ###*

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -156,17 +156,14 @@ app.boot "/view/thread.html", ->
         return
 
       $last = $content.C("last")[0]
-      lastNum = 0
-      for dom in $content.$$(":scope > article:last-child")
-        lastNum = +dom.C("num")[0].textContent
-        break
+      lastNum = $content.$(":scope > article:last-child").C("num")[0].textContent
       # 指定レス番号へ
       if 0 < jumpResNum <= lastNum
         threadContent.select(jumpResNum, false, true, -60)
       # 最終既読位置へ
       else if $last?
         offset = $last.attr("last-offset") ? 0
-        threadContent.scrollTo(+$last.C("num")[0].textContent, false, +offset)
+        threadContent.scrollTo($last, false, +offset)
 
       #スクロールされなかった場合も余所の処理を走らすためにscrollを発火
       unless on_scroll
@@ -193,17 +190,15 @@ app.boot "/view/thread.html", ->
                 offset = $tmp?.attr("last-offset") ? -100
               $tmp ?= $content.$(":scope > article.read")
               $tmp ?= $content.$(":scope > article:last-child")
-              threadContent.scrollTo(+$tmp.C("num")[0].textContent, true, +offset) if $tmp?
+              threadContent.scrollTo($tmp, true, +offset) if $tmp?
           when "surely_new"
-            for dom, i in $content.child() when dom.matches(".last.received + article")
-              res_num = i+1
+            for dom in $content.child() when dom.matches(".last.received + article")
+              $res = dom
               break
-            threadContent.scrollTo(res_num, true) if typeof res_num is "number"
+            threadContent.scrollTo($res, true) if $res?
           when "newest"
-            for dom, i in $content.child() when dom.matches("article:last-child")
-              res_num = i+1
-              break
-            threadContent.scrollTo(res_num, true) if typeof res_num is "number"
+            $res = $content.$(":scope > article:last-child")
+            threadContent.scrollTo($res, true) if $res?
 
     jumpResNum = -1
     iframe = parent.$$.$("iframe[data-url=\"#{view_url}\"]")
@@ -337,7 +332,7 @@ app.boot "/view/thread.html", ->
       app.NG.add("Slip:" + $res.dataset.slip)
 
     else if target.hasClass("jump_to_this")
-      threadContent.scrollTo(+$res.C("num")[0].textContent, true)
+      threadContent.scrollTo($res, true)
 
     else if target.hasClass("res_to_this")
       write(message: ">>#{$res.C("num")[0].textContent}\n")
@@ -695,15 +690,12 @@ app.boot "/view/thread.html", ->
           break
 
       if selector
-        res_num = 1
-        for dom, i in $view.T("article") when dom.matches(selector)
-          res_num = i + 1
-          break
-        if key is ".jump_last"
-          offset = dom.attr("last-offset") ? offset
+        $res = $view.$(selector)
 
-        if typeof res_num is "number"
-          threadContent.scrollTo(res_num, true, +offset)
+        if $res?
+          if key is ".jump_last"
+            offset = $res.attr("last-offset") ? offset
+          threadContent.scrollTo($res, true, +offset)
         else
           app.log("warn", "[view_thread] .jump_panel: ターゲットが存在しません")
       return

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -190,7 +190,7 @@ app.boot "/view/thread.html", ->
               # 新着が存在しない場合はスクロールを実行するためにレスを探す
               unless $tmp?
                 $tmp = $content.$(":scope > article.last")
-                offset = $tmp.attr("last-offset") ? -100
+                offset = $tmp?.attr("last-offset") ? -100
               $tmp ?= $content.$(":scope > article.read")
               $tmp ?= $content.$(":scope > article:last-child")
               threadContent.scrollTo(+$tmp.C("num")[0].textContent, true, +offset) if $tmp?


### PR DESCRIPTION
Fix: jumpResNumを共有しないように
 - 初回読み込み時の`jumpResNum`と開いている状態でのジャンプの`jumpResNum`が混ざらないように分離

Fix: selectにanimate, offsetを送れるように+jumpResの処理は_drawで
 - `select(target, preventScroll = false, animate = false, offset = 0)`
 - `jumpRes`の処理を読み込み時のスクロールがある`read_state_attached`にするため`_draw`にわたすように

Fix: readStateAttachedフラグではなくmaybeTempを引数で渡すように
 - `_draw`で初回か二回目かを`view_loaded`わたすように
 - それによって`view_loaded`を整理

~~Fix: requestReloadFlagをmaybeTempで書き換え~~
 - ~~`reload_request`で二回`scan`が起こる ->`maybeTemp`で書き換え可~~
 - ~~**WIP**~~
 - ~~**保存されないバグ**~~
うまい実装方法を思いつかなかったので諦め…

Fix: scrollToにElementを渡すこともできるように
 - `scrollTo`にElement自体を渡せるように

Fix: 新着スクロールが実行されないことがあるのを修正

Fix: ブックマークにないスレの既読情報を更新しようとしたときにrejectしないように
 - `catch`されませんでしたのエラー表示を減らすため

refs #342 

cc / @eru 