### PR TITLE
Fix: スレッドのオープン及びリロード時のスクロールに関する修正など

### DIFF
--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -275,7 +275,8 @@ class UI.ThreadContent
           @container.dispatchEvent(new Event("scrollstart"))
 
           to = target.offsetTop + offset
-          change = (to - @container.scrollTop)/15
+          movingHeight = to - @container.scrollTop
+          change = Math.max(Math.round(movingHeight / 15), 1)
           min = Math.min(to-change, to+change)
           max = Math.max(to-change, to+change)
           @_scrollRequestID = requestAnimationFrame(_scrollInterval = =>
@@ -283,6 +284,9 @@ class UI.ThreadContent
             # 画像のロードによる座標変更時の補正
             if to isnt target.offsetTop + offset
               to = target.offsetTop + offset
+              if to - @container.scrollTop > movingHeight
+                movingHeight = to - @container.scrollTop
+                change = Math.max(Math.round(movingHeight / 15), 1)
               min = Math.min(to-change, to+change)
               max = Math.max(to-change, to+change)
             # 例外発生時の停止処理

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -84,6 +84,20 @@ class UI.ThreadContent
     ###
     @_hiddenSelectors = null
 
+    ###*
+    @property _isScrolling
+    @type Boolean
+    @private
+    ###
+    @_isScrolling = false
+
+    ###*
+    @property _scrollRequestID
+    @type Number
+    @private
+    ###
+    @_scrollRequestID = 0
+
     try
       @harmfulReg = new RegExp(app.config.get("image_blur_word"))
       @findHarmfulFlag = true
@@ -96,6 +110,14 @@ class UI.ThreadContent
         background_color: "red"
       )
       @findHarmfulFlag = false
+
+    @container.on "scrollstart", =>
+      @_isScrolling = true
+      return
+
+    @container.on "scrollfinish", =>
+      @_isScrolling = false
+      return
 
     return
 
@@ -248,6 +270,7 @@ class UI.ThreadContent
 
       # スクロールの実行
       if animate
+        cancelAnimationFrame(@_scrollRequestID) if @_isScrolling
         do =>
           @container.dispatchEvent(new Event("scrollstart"))
 
@@ -255,7 +278,7 @@ class UI.ThreadContent
           change = (to - @container.scrollTop)/15
           min = Math.min(to-change, to+change)
           max = Math.max(to-change, to+change)
-          requestAnimationFrame(_scrollInterval = =>
+          @_scrollRequestID = requestAnimationFrame(_scrollInterval = =>
             before = @container.scrollTop
             # 画像のロードによる座標変更時の補正
             if to isnt target.offsetTop + offset
@@ -280,7 +303,7 @@ class UI.ThreadContent
             if @container.scrollTop is before
               @container.dispatchEvent(new Event("scrollfinish"))
               return
-            requestAnimationFrame(_scrollInterval)
+            @_scrollRequestID = requestAnimationFrame(_scrollInterval)
             return
           )
       else

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -9,6 +9,8 @@ window.UI ?= {}
 @requires MediaContainer
 ###
 class UI.ThreadContent
+  _OVER1000_DATA = "Over 1000"
+
   constructor: (@url, @container) ->
     ###*
     @property idIndex
@@ -97,6 +99,13 @@ class UI.ThreadContent
     @private
     ###
     @_scrollRequestID = 0
+
+    ###*
+    @property _over1000Res
+    @type Boolean
+    @private
+    ###
+    @_over1000Res = false
 
     try
       @harmfulReg = new RegExp(app.config.get("image_blur_word"))
@@ -513,6 +522,7 @@ class UI.ThreadContent
         return
 
       resNum = @container.child().length
+      {bbsType} = app.URL.guessType(@url)
 
       app.WriteHistory.getByUrl(@url).then( (writtenRes) =>
         html = ""
@@ -617,6 +627,13 @@ class UI.ThreadContent
 
           articleHtml += "</header>"
 
+          # スレッド終端の自動追加メッセージの確認
+          if (
+            bbsType is "2ch" and
+            tmp.startsWith(_OVER1000_DATA)
+          )
+            @_over1000Res = true
+
           #文字色
           color = res.message.match(/<font color="(.*?)">/i)
 
@@ -626,8 +643,7 @@ class UI.ThreadContent
             res.class.push("ng")
             res.attr["ng-type"] = ngType
           else
-            guessType = app.URL.guessType(@url)
-            if guessType.bbsType is "2ch" and resNum <= 1000
+            if bbsType is "2ch" and !@_over1000Res
               # idなしをNG
               if (
                 app.config.isOn("nothing_id_ng") and !res.id? and

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -179,7 +179,6 @@ class UI.ThreadList
           res = tr.$(selector.res)
           if +res.textContent < read_state.received
             res.textContent = read_state.received
-            tr.addClass("updated")
           unread = tr.$(selector.unread)
           unreadCount = Math.max(+res.textContent - read_state.read, 0)
           unread.textContent = unreadCount or ""


### PR DESCRIPTION
【スクロールに関する修正】
・スクロールの完了に時間が掛かることがある
1. `change`の値に実数を使用しているため`scrollTop`へのセット時に小数点以下が切り捨てられ、想定数以上の回数(時間)を必要とすることがある。四捨五入を行うことにより想定数に近づけるようにする。
2. 最終レスから新着へのスクロール時に最終レスに貼られた画像がロードされると移動量が大幅に増加するが、座標補正時に`change`の再算出をしていなかった。

・スレッドのオープン時には`ThreadContent.scrollTo()`のパラメータとして、1回目(キャッシュ読み込み分)は`animate = false`, `offset = 0`を指定し、2回目(新着分)では`animate = true`, `offset = -100`を指定しているが、リロード時は2回とも`animate = true`, `offset = -100`が指定されている。その結果として、`requestAnimationFrame()`の衝突による不具合や逆方向へのスクロールが発生することがあった。リロード時も1回目は`animate = false`, `offset = 0`として実行するように変更。

・遅延スクロール前に仮スクロールを実行していたが、アニメーション処理が殆ど行われず不自然なことになっていたので、事前処理自体を廃止し、連続してアニメーション処理を行うように変更。

【その他】
1000レスを超えた場合でもID/SLIPなしのNGを有効にする
　・スレッド終端の自動追加メッセージを、日時欄の`"Over 1000 Thread"`(scの場合は`"Over 1000Thread"`)で判断するようにする。

　
スレッド一覧のレス数更新処理の誤りを修正
　・クラス`updated`の意味を勘違いし必要のない追加を行っていた。
