### PR TITLE
閲覧履歴と書き込み履歴のバグ修正

### DIFF
--- a/src/core/History.coffee
+++ b/src/core/History.coffee
@@ -75,9 +75,7 @@ class app.History
             resolve()
             return
           if date?
-            ddate = cursor.value.date
-            if date < ddate < date + 60*1000
-              cursor.delete()
+            cursor.delete() if date is cursor.value.date
           else
             cursor.delete()
           cursor.continue()

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -297,6 +297,14 @@ do ->
 
   app.util.stringToDate = (string) ->
     date = string.match(/(\d{4})\/(\d{1,2})\/(\d{1,2})(?:\(.\))?\s?(\d{1,2}):(\d\d)(?::(\d\d)(?:\.\d+)?)?/)
-    if date.length >= 5
-      return new Date(date[1], date[2], date[3], date[4], date[5], date[6] ? 0)
+    flg = false
+    if date?
+      flg = true if date[1]?
+      flg = false unless date[2]? and 1 <= +date[2] <= 12
+      flg = false unless date[3]? and 1 <= +date[3] <= 31
+      flg = false unless date[4]? and 0 <= +date[4] <= 23
+      flg = false unless date[5]? and 0 <= +date[5] <= 59
+      date[6] = 0 unless date[6]? and 0 <= +date[6] <= 59
+    if flg
+      return new Date(date[1], date[2] - 1, date[3], date[4], date[5], date[6])
     return null

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -267,7 +267,7 @@ class UI.ThreadList
               threadTitle = $tr.$(selector.title)?.textContent
               threadRes = $tr.$(selector.res)?.textContent
               threadWrittenRes = parseInt($tr.$(selector.writtenRes)?.textContent ? 0)
-              date = $tr.$(selector.viewedDate)?.textContent
+              dateValue = $tr.$(selector.viewedDate)?.getAttr("date-value")
 
               switch true
                 when e.target.hasClass("add_bookmark")
@@ -275,7 +275,7 @@ class UI.ThreadList
                 when e.target.hasClass("del_bookmark")
                   app.bookmark.remove(threadURL)
                 when e.target.hasClass("del_history")
-                  app.History.remove(threadURL, app.util.stringToDate(date))
+                  app.History.remove(threadURL, +dateValue)
                   $tr.remove()
                 when e.target.hasClass("del_writehistory")
                   app.WriteHistory.remove(threadURL, threadWrittenRes)
@@ -424,7 +424,7 @@ class UI.ThreadList
 
       #閲覧日時
       if @_flg.viewedDate
-        tmpHTML += "<td>"
+        tmpHTML += "<td date-value=\"#{item.date}\">"
         tmpHTML += app.escapeHtml(ThreadList._dateToString(new Date(item.date)))
         tmpHTML += "</td>"
 


### PR DESCRIPTION
こちらは検証する時間が必要かと思い、PRを分割しました。

1. 閲覧履歴の削除が出来ていない
　一覧に表示している時間を使用して指定時間+60秒以内のデータを削除しようとしているようですが、うまく機能していないことと、想定外のデータまで削除される可能性があるため、ピンポイントで削除するように変更しました。

2. 書き込み履歴が1ヶ月ずれている
　去年の10月22日のリリース以降の問題と思われるので、それ以降のデータのリカバリーも含めました。
　ただし、新バージョンへの更新日が分からないので、スレ立て分を除いた2017年11月以降のデータのみ対象にしています。
　また、10月31日の登録分は、内部的に11月31日→12月1日と置き換わっているために、リカバリー後は11月1日になってしまうなどの問題もあります。
　リカバリーなど必要ない。履歴をまるごと捨ててしまえばいい。と言う意見ならばリカバリー処理を削除しますが・・・

あと、NG関連の修正もありますが、後日PRする予定です。