### PR TITLE
したらばのSSL対応の準備及びその他

### DIFF
--- a/src/view/board.coffee
+++ b/src/view/board.coffee
@@ -44,10 +44,6 @@ app.boot("/view/board.html", ["board"], (Board) ->
   else
     $writeButton.remove()
 
-  # 現状ではしたらばはhttpsに対応していないので切り替えボタンを隠す
-  if app.URL.tsld(url) is "shitaraba.net"
-    $view.C("button_scheme")[0].remove()
-
   # ソート関連
   do ->
     lastBoardSort = app.config.get("last_board_sort_config")

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -452,7 +452,9 @@ app.boot("/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
                 $key.checked = (value is "on")
                 $key.dispatchEvent(new Event("change"))
               when "radio"
-                $key.value = value
+                for dom in $view.$$("input.direct[name=\"#{key}\"]")
+                  if dom.value is value
+                    dom.checked = true
                 $key.dispatchEvent(new Event("change"))
           else
             $keyTextArea = $view.$("textarea[name=\"#{key}\"]")

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -685,7 +685,7 @@ app.boot("/view/thread.html", ->
     app.contextMenus.update("add_media_to_ngwords", {
       title: menuTitle,
       onclick: (info, tab) =>
-        app.NG.add(@src)
+        app.NG.add(target.src)
         threadContent.refreshNG()
         return
     })

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -102,10 +102,6 @@ app.boot("/view/thread.html", ->
   else
     $view.C("button_write")[0].remove()
 
-  # 現状ではしたらばはhttpsに対応していないので切り替えボタンを隠す
-  if app.URL.tsld(viewUrl) is "shitaraba.net"
-    $view.C("button_scheme")[0].remove()
-
   #リロード処理
   $view.on("request_reload", ({ detail: ex = {} }) ->
     threadContent.refreshNG()


### PR DESCRIPTION
したらばのSSL対応に向けて、`http/https`切り替えボタンを有効にしました。
スレッドの読み込み失敗時など他にも修正が必要な箇所が発生するかもしれませんが、現在のところ不明なのでそのままになっています。
