### PR TITLE
Fix: したらばSSL対応の準備 refs #419

### DIFF
--- a/src/view/board.coffee
+++ b/src/view/board.coffee
@@ -44,10 +44,6 @@ app.boot("/view/board.html", ["board"], (Board) ->
   else
     $writeButton.remove()
 
-  # 現状ではしたらばはhttpsに対応していないので切り替えボタンを隠す
-  if app.URL.tsld(url) is "shitaraba.net"
-    $view.C("button_scheme")[0].remove()
-
   # ソート関連
   do ->
     lastBoardSort = app.config.get("last_board_sort_config")

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -102,10 +102,6 @@ app.boot("/view/thread.html", ->
   else
     $view.C("button_write")[0].remove()
 
-  # 現状ではしたらばはhttpsに対応していないので切り替えボタンを隠す
-  if app.URL.tsld(viewUrl) is "shitaraba.net"
-    $view.C("button_scheme")[0].remove()
-
   #リロード処理
   $view.on("request_reload", ({ detail: ex = {} }) ->
     threadContent.refreshNG()


### PR DESCRIPTION
したらばのSSL対応に備え、`http/https切り替えボタン`を使用可能にしました。
