### PR TITLE
Update: スレ検索のhttps対応 close #423

### DIFF
--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -424,7 +424,7 @@ app.main = ->
           modal: true
     if res = /^search:(.+)$/.exec(url)
       return
-        src: "/view/search.html?#{app.URL.buildQuery(query: res[1])}"
+        src: "/view/search.html?#{res[1]}"
         url: url
     if guessResult.type is "board"
       return

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -637,16 +637,29 @@ class app.view.TabContentView extends app.view.PaneContentView
 
     return unless $button
     {url} = @$element.dataset
+    viewSearch = false
+    if url.startsWith("search:")
+      viewSearch = true
+      searchParam = url.substr(7)
+      searchScheme = @$element.getAttr("scheme") ? "http"
 
-    if ///^https?://\w///.test(url)
-      if app.URL.getScheme(url) is "https"
+    if ///^https?://\w///.test(url) or viewSearch
+      if (
+        app.URL.getScheme(url) is "https" or
+        (viewSearch and searchScheme is "https")
+      )
         $button.addClass("https")
       else
         $button.removeClass("https")
 
       $button.on("click", ->
+        if viewSearch
+          url = "search:" + app.URL.buildQuery(query: searchParam)
+          url += "&https" if searchScheme isnt "https"
+        else
+          url = app.URL.changeScheme(url)
         app.message.send("open",
-          url: app.URL.changeScheme(url),
+          url: url,
           new_tab: app.config.isOn("button_change_scheme_newtab")
         )
         return

--- a/src/view/search.pug
+++ b/src/view/search.pug
@@ -19,6 +19,7 @@ block body
     .button.button_back.disabled(title="戻る")
     .button.button_forward.disabled(title="進む")
     .button.button_reload(title="再読み込み")
+    .button.button_scheme(title="http/httpsの切り替え")
     .button.button_tool(title="メニュー")
       ul.hidden
         li.button_link: a(target="_blank") Chromeで直接開く

--- a/src/view/search.scss
+++ b/src/view/search.scss
@@ -29,6 +29,11 @@ td {
   }
 }
 
+tr.https td:nth-child(2)::before {
+    content: url(/img/lock_12x12_3a5.webp);
+    vertical-align: middle;
+}
+
 .theme_default {
   .more:hover {
     background: #e8e8e8;

--- a/src/view/sidemenu.coffee
+++ b/src/view/sidemenu.coffee
@@ -31,7 +31,9 @@ app.boot("/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
   )
   $view.C("search")[0].on("submit", (e) ->
     e.preventDefault()
-    app.message.send("open", {url: "search:#{@q.value}", new_tab: true})
+    param = app.URL.buildQuery(query: @q.value)
+    param += "&https" if app.config.get("thread_search_last_mode") is "https"
+    app.message.send("open", {url: "search:#{param}", new_tab: true})
     @q.value = ""
     return
   )


### PR DESCRIPTION
スレ検索の`https`対応が抜けていたので追加しました。
実際の検索は、`ThreadSearch.coffee`内で`https`固定で呼び出していますが、特に変更の必要がなさそうなのでそのままにしてあります。