### PR TITLE
Fix: ポップアップ内でのコンテキストメニュー表示方法の変更 close #430

### DIFF
--- a/src/ui/ContextMenu.coffee
+++ b/src/ui/ContextMenu.coffee
@@ -1,7 +1,13 @@
 window.UI ?= {}
 do ->
+  altParent = null
+
   cleanup = ->
     $$.C("contextmenu_menu")[0]?.remove()
+    if altParent
+      altParent.removeClass("has_contextmenu")
+      altParent.dispatchEvent(new Event("contextmenu_removed"))
+      altParent = null
     return
 
   eventFn = (e) ->
@@ -24,7 +30,7 @@ do ->
     return
   )
 
-  UI.ContextMenu = ($menu, x, y) ->
+  UI.ContextMenu = ($menu, x, y, $parent = null) ->
     cleanup()
 
     $menu.addClass("contextmenu_menu")
@@ -32,6 +38,9 @@ do ->
     menuWidth = $menu.offsetWidth
     $menu.style.left = "#{x}px"
     $menu.style.top = "#{y}px"
+    if $parent
+      altParent = $parent
+      altParent.addClass("has_contextmenu")
 
     if window.innerWidth < $menu.offsetLeft + menuWidth
       $menu.style.left = ""
@@ -39,3 +48,6 @@ do ->
     if window.innerHeight < $menu.offsetTop + $menu.offsetHeight
       $menu.style.top = "#{Math.max($menu.offsetTop - $menu.offsetHeight, 0)}px"
     return
+
+  UI.ContextMenu.remove = ->
+    cleanup()

--- a/src/ui/PopupView.coffee
+++ b/src/ui/PopupView.coffee
@@ -101,6 +101,9 @@ class UI.PopupView
       clearTimeout(@_delayTimeoutID)
       @_delayTimeoutID = 0
 
+    # コンテキストメニューの破棄
+    UI.ContextMenu.remove()
+
     # 表示位置の決定
     setDispPosition = (popupNode) =>
       margin = 20
@@ -147,11 +150,12 @@ class UI.PopupView
           popupNode.style.maxHeight = "#{viewHeight - cssTop - margin}px"
       return
 
-    # マウス座標の監視
+    # マウス座標とコンテキストメニューの監視
     if @_popupStack.length is 0
       @_currentX = @mouseX
       @_currentY = @mouseY
       @defaultParent.on("mousemove", @_onMouseMove)
+      @_popupArea.on("contextmenu_removed", @_onRemoveContextmenu)
 
     # 新規ノードの設定
     setupNewNode = (sourceNode, popupNode) =>
@@ -210,6 +214,7 @@ class UI.PopupView
   @param {Boolean} forceRemove
   ###
   _remove: (forceRemove) ->
+    return if @_popupArea.hasClass("has_contextmenu")
     for {popup, source} in @_popupStack by -1
       # 末端の非アクティブ・ノードを選択
       break if (
@@ -228,10 +233,14 @@ class UI.PopupView
       source.removeAttr("stack-index")
       popup.remove()
       @_popupStack.pop()
+      # コンテキストメニューの破棄
+      if @_popupArea.hasClass("has_contextmenu")
+        UI.ContextMenu.remove()
 
-    # マウス座標の監視終了
+    # マウス座標とコンテキストメニューの監視終了
     if @_popupStack.length is 0
       @defaultParent.off("mousemove", @_onMouseMove)
+      @_popupArea.off("contextmenu_removed", @_onRemoveContextmenu)
     return
 
   ###*
@@ -271,6 +280,7 @@ class UI.PopupView
   ###
   _onMouseLeave: ({ currentTarget: target }) =>
     target.removeClass("active")
+    return if @_popupArea.hasClass("has_contextmenu")
     @_delayRemove(false)
     return
 
@@ -300,6 +310,14 @@ class UI.PopupView
       @source.removeClass("active")
       @popup.removeClass("active")
       @_delayRemove(false)
+    return
+
+  ###*
+  @method _onRemoveContextmenu
+  ###
+  _onRemoveContextmenu: =>
+    @_activateNode()
+    @_remove(false)
     return
 
   ###*

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -243,7 +243,13 @@ app.boot("/view/thread.html", ->
     $article = target.parent()
     $menu = $$.I("template_res_menu").content.$(".res_menu").cloneNode(true)
     $menu.addClass("hidden")
-    $article.addLast($menu)
+    altParent = null
+    if $article.parent().hasClass("popup")
+      altParent = $view.C("popup_area")[0]
+      altParent.addLast($menu)
+      $menu.setAttr("resnum", $article.C("num")[0].textContent)
+    else
+      $article.addLast($menu)
 
     $toggleAaMode = $menu.C("toggle_aa_mode")[0]
     if $article.parent().hasClass("config_use_aa_font")
@@ -290,7 +296,7 @@ app.boot("/view/thread.html", ->
       $menu.C("search_selection")[0].remove()
 
     $menu.removeClass("hidden")
-    UI.ContextMenu($menu, e.clientX, e.clientY)
+    UI.ContextMenu($menu, e.clientX, e.clientY, altParent)
     return
 
   $view.on("click", onHeaderMenu)
@@ -315,6 +321,9 @@ app.boot("/view/thread.html", ->
   $view.on("click", ({target}) ->
     return unless target.matches(".res_menu > li")
     $res = target.closest("article")
+    unless $res
+      rn = +target.closest(".res_menu").getAttr("resnum")
+      $res = $content.child()[rn - 1]
 
     if target.hasClass("copy_selection")
       selectedText = getSelection().toString()


### PR DESCRIPTION
掲示板の書き込みを見ると、Chrome68では現象が発生していないようですが、私の方で確認した範囲内では、Windows/Linux共に特に違いが無かったので、ポップアップ内でのコンテキストメニューの表示方法を変更してみました。

見当違いの修正であれば、PRを取り下げます。