### PR TITLE
NGの表示に関する修正と短縮URLの対象追加

### DIFF
--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -158,6 +158,7 @@ namespace app {
       "cas.st",
       "cos.lv",
       "dlvr.it",
+      "ekaz10.xyz",
       "fb.me",
       "g.co",
       "goo.gl",
@@ -168,6 +169,7 @@ namespace app {
       "j.mp",
       "jump.cx",
       "kkbox.fm",
+      "morimo2.info",
       "ow.ly",
       "p.tl",
       "prt.nu",
@@ -180,6 +182,8 @@ namespace app {
       "tl.gd",
       "tr.im",
       "trib.al",
+      "qq4q.biz",
+      "u0u1.net",
       "ur0.biz",
       "ur0.work",
       "url.ie",
@@ -190,6 +194,8 @@ namespace app {
       "ur0.pw",
       "ur2.link",
       "ustre.am",
+      "ux.nu",
+      "wb2.biz",
       "wk.tk",
       "xrl.us"
     ]);

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -399,6 +399,7 @@ app.boot("/view/thread.html", ->
 
     popupHelper(target, e, =>
       $popup = $__("div")
+      resCount = 0
 
       if target.hasClass("disabled")
         $div = $__("div")
@@ -414,17 +415,25 @@ app.boot("/view/thread.html", ->
           $div.addClass("popup_disabled")
           $popup.addLast($div)
         else if 0 < anchorData.targetCount
+          resCount = anchorData.targetCount
           tmp = $content.child()
           for [start, end] in anchorData.segments
             for i in [start..end]
               now = i-1
-              break unless tmp[now]
-              $popup.addLast(tmp[now].cloneNode(true))
+              break unless res = tmp[now]
+              continue if res.hasClass("ng") and !res.hasClass("disp_ng")
+              $popup.addLast(res.cloneNode(true))
 
-      if $popup.child().length is 0
+      popupCount = $popup.child().length
+      if popupCount is 0
         $div = $__("div")
         $div.textContent = "対象のレスが見つかりません"
         $div.addClass("popup_disabled")
+        $popup.addLast($div)
+      else if popupCount < resCount
+        $div = $__("div")
+        $div.addClass("ng_count")
+        $div.setAttr("ng-count", resCount - popupCount)
         $popup.addLast($div)
 
       return $popup
@@ -568,24 +577,41 @@ app.boot("/view/thread.html", ->
       )
         nowPopuping = "トリップ"
 
+      resCount = 0
       if nowPopuping isnt ""
         $div = $__("div")
         $div.textContent = "現在ポップアップしている#{nowPopuping}です"
         $div.addClass("popup_disabled")
         $popup.addLast($div)
       else if threadContent.idIndex.has(id)
+        resCount = threadContent.idIndex.get(id).size
         for resNum from threadContent.idIndex.get(id)
-          $popup.addLast($content.child()[resNum - 1].cloneNode(true))
+          targetRes = $content.child()[resNum - 1]
+          continue if targetRes.hasClass("ng") and !targetRes.hasClass("disp_ng")
+          $popup.addLast(targetRes.cloneNode(true))
       else if threadContent.slipIndex.has(slip)
+        resCount = threadContent.slipIndex.get(slip).size
         for resNum from threadContent.slipIndex.get(slip)
-          $popup.addLast($content.child()[resNum - 1].cloneNode(true))
+          targetRes = $content.child()[resNum - 1]
+          continue if targetRes.hasClass("ng") and !targetRes.hasClass("disp_ng")
+          $popup.addLast(targetRes.cloneNode(true))
       else if threadContent.tripIndex.has(trip)
+        resCount = threadContent.tripIndex.get(trip).size
         for resNum from threadContent.tripIndex.get(trip)
-          $popup.addLast($content.child()[resNum - 1].cloneNode(true))
-      else
+          targetRes = $content.child()[resNum - 1]
+          continue if targetRes.hasClass("ng") and !targetRes.hasClass("disp_ng")
+          $popup.addLast(targetRes.cloneNode(true))
+
+      popupCount = $popup.child().length
+      if popupCount is 0
         $div = $__("div")
         $div.textContent = "対象のレスが見つかりません"
         $div.addClass("popup_disabled")
+        $popup.addLast($div)
+      else if popupCount < resCount
+        $div = $__("div")
+        $div.addClass("ng_count")
+        $div.setAttr("ng-count", resCount - popupCount)
         $popup.addLast($div)
       return $popup
     )
@@ -600,12 +626,26 @@ app.boot("/view/thread.html", ->
       tmp = $content.child()
 
       frag = $_F()
-      res_num = +target.closest("article").C("num")[0].textContent
-      for target_res_num from threadContent.repIndex.get(res_num)
-        frag.addLast(tmp[target_res_num - 1].cloneNode(true))
+      resNum = +target.closest("article").C("num")[0].textContent
+      for targetResNum from threadContent.repIndex.get(resNum)
+        targetRes = tmp[targetResNum - 1]
+        continue if targetRes.hasClass("ng") and !targetRes.hasClass("disp_ng")
+        frag.addLast(targetRes.cloneNode(true))
 
       $popup = $__("div")
       $popup.addLast(frag)
+      resCount = threadContent.repIndex.get(resNum).size
+      popupCount = $popup.child().length
+      if popupCount is 0
+        $div = $__("div")
+        $div.textContent = "対象のレスが見つかりません"
+        $div.addClass("popup_disabled")
+        $popup.addLast($div)
+      else if popupCount < resCount
+        $div = $__("div")
+        $div.addClass("ng_count")
+        $div.setAttr("ng-count", resCount - popupCount)
+        $popup.addLast($div)
       return $popup
     )
     return

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -70,20 +70,15 @@ article {
 
     .popup & {
       display: block;
-      color: #666;
-      border: 1px dashed;
-      padding: 5px;
-      margin: 5px;
 
       &::after {
         display: block;
-        margin: 0px;
-        min-width: 10em;
-        content: "NG";
-        text-align: center;
+        margin: 5px 10px;
+        color: gray;
+        content: "あぼーん (" attr(ng-type) ")";
       }
 
-      > header, > .message {
+      > .message {
         display: none;
       }
     }
@@ -269,6 +264,21 @@ header {
     background-color: rgba(black, 0.8);
     color: #eeeeee;
     animation: fade_in 150ms ease-out;
+  }
+  .ng_count {
+    display: block;
+    color: #666;
+    border: 1px dashed;
+    padding: 5px;
+    margin: 5px;
+    &::after {
+      display: block;
+      margin: 0px;
+      min-width: 10em;
+      color: gray;
+      content: "他 NG " attr(ng-count) "件";
+      text-align: center;
+    }
   }
 }
 .popup_disabled {

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -434,6 +434,15 @@ header {
   $res-name-to-own-ob-color,
   $link-color,
   $freq-color,
+  $ng-res-header-color,
+  $ng-res-name-color,
+  $ng-res-name-ob-color,
+  $ng-res-name-own-color,
+  $ng-res-name-own-ob-color,
+  $ng-res-name-to-own-color,
+  $ng-res-name-to-own-ob-color,
+  $ng-link-color,
+  $ng-freq-color,
   $anchor-color,
   $anchor-active-color,
   $anchor-visited-color,
@@ -501,6 +510,40 @@ header {
     color: $freq-color;
   }
 
+    .ng {
+      header {
+        color: $ng-res-header-color;
+      }
+      .name {
+        color: $ng-res-name-color;
+      }
+      .ob {
+        color: $ng-res-name-ob-color;
+      }
+      .link, .beid, .beid:visited {
+        color: $ng-link-color;
+      }
+      .freq {
+        color: $ng-freq-color;
+      }
+      &.to_written {
+        .name {
+          color: $ng-res-name-to-own-color;
+        }
+        .ob {
+          color: $ng-res-name-to-own-ob-color;
+        }
+      }
+      &.written {
+        .name {
+          color: $ng-res-name-own-color;
+        }
+        .ob {
+          color: $ng-res-name-own-ob-color;
+        }
+      }
+    }
+
   .anchor.disabled {
     color: $anchor-disabled-color;
   }
@@ -559,6 +602,15 @@ header {
     $res-name-to-own-ob-color: #cd853f,
     $link-color: #00a,
     $freq-color: #a00,
+    $ng-res-header-color: #888,
+    $ng-res-name-color: #7a7,
+    $ng-res-name-ob-color: #58a,
+    $ng-res-name-own-color: #ff6540,
+    $ng-res-name-own-ob-color: #ff9b40,
+    $ng-res-name-to-own-color: #ffac40,
+    $ng-res-name-to-own-ob-color: #efaa6f,
+    $ng-link-color: #88b,
+    $ng-freq-color: #b88,
     $anchor-color: #00e,
     $anchor-active-color: hsl(10, 50%, 50%),
     $anchor-visited-color: #551A8B,
@@ -588,6 +640,15 @@ header {
     $res-name-to-own-ob-color: #cd853f,
     $link-color: #69d,
     $freq-color: #d99,
+    $ng-res-header-color: #888,
+    $ng-res-name-color: #6a6,
+    $ng-res-name-ob-color: #67b,
+    $ng-res-name-own-color: #c22530,
+    $ng-res-name-own-ob-color: #c25b30,
+    $ng-res-name-to-own-color: #c07730,
+    $ng-res-name-to-own-ob-color: #b4752f,
+    $ng-link-color: #66b,
+    $ng-freq-color: #a66,
     $anchor-color: #6af,
     $anchor-active-color: hsl(30, 50%, 50%),
     $anchor-visited-color: #99f,


### PR DESCRIPTION
- 短縮URLの対象として、`ekaz10.xyz`, `morimo2.info`, `qq4q.biz`, `u0u1.net`, `ux.nu`, `wb2.biz`を追加しました。
- あぼーん表示をする設定の場合のヘッダーの文字色を変更しました。
- ポップアップ内でのNGの扱いを、本文のあぼーん表示の設定と連動するようにしました。
なお、表示しない設定の場合はNGの件数を追加で表示します。

以上、よろしくお願いします。