### PR TITLE
Fix: ポップアップがAA表示に対応していなかったのを修正

### DIFF
--- a/src/ui/ContextMenu.coffee
+++ b/src/ui/ContextMenu.coffee
@@ -6,6 +6,7 @@ do ->
     $$.C("contextmenu_menu")[0]?.remove()
     if altParent
       altParent.removeClass("has_contextmenu")
+      altParent.$(".popup.has_contextmenu").removeClass("has_contextmenu")
       altParent.dispatchEvent(new Event("contextmenu_removed"))
       altParent = null
     return

--- a/src/ui/PopupView.coffee
+++ b/src/ui/PopupView.coffee
@@ -168,6 +168,8 @@ class UI.PopupView
       sourceNode.on("mouseenter", @_onMouseEnter)
       sourceNode.on("mouseleave", @_onMouseLeave)
       popupNode.addClass("popup")
+      if app.config.get("aa_font") is "aa"
+        popupNode.addClass("config_use_aa_font")
       popupNode.setAttr("stack-index", @_popupStack.length)
       popupNode.on("mouseenter", @_onMouseEnter)
       popupNode.on("mouseleave", @_onMouseLeave)

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -242,6 +242,7 @@ app.boot("/view/thread.html", ->
       altParent = $view.C("popup_area")[0]
       altParent.addLast($menu)
       $menu.setAttr("resnum", $article.C("num")[0].textContent)
+      $article.parent().addClass("has_contextmenu")
     else
       $article.addLast($menu)
 
@@ -316,8 +317,11 @@ app.boot("/view/thread.html", ->
     return unless target.matches(".res_menu > li")
     $res = target.closest("article")
     unless $res
-      rn = +target.closest(".res_menu").getAttr("resnum")
-      $res = $content.child()[rn - 1]
+      rn = target.closest(".res_menu").getAttr("resnum")
+      for res in $view.$$(".popup.has_contextmenu > article")
+        if res.C("num")[0].textContent is rn
+          $res = res
+          break
 
     if target.hasClass("copy_selection")
       selectedText = getSelection().toString()


### PR DESCRIPTION
```
419名無しさんsage2018/06/24(日) 21:47:29ID:BrkUhTpU(1)
デフォルトのCSSでは、ポップアップのAA判定レス(.aa)に対して
AA向けスタイルが適用されないようです。
```

ポップアップとコンテキストメニューを修正しました。