### PR TITLE
Update: スレ内検索で正規表現を使用可能にする refs #125

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -116,6 +116,8 @@ imgs = [
   "unlock_19x19_333.webp"
   "pause_19x19_333.webp"
   "pause_19x19_811.webp"
+  "regexp_19x19_333.webp"
+  "regexp_19x19_06e.webp"
 
   "arrow_19x19_ddd_r90.webp"
   "arrow_19x19_ddd_r-90.webp"
@@ -129,6 +131,8 @@ imgs = [
   "unlock_19x19_ddd.webp"
   "pause_19x19_ddd.webp"
   "pause_19x19_a33.webp"
+  "regexp_19x19_ddd.webp"
+  "regexp_19x19_f93.webp"
 ]
 # -------
 sass.compiler = sassCompiler

--- a/src/common.scss
+++ b/src/common.scss
@@ -135,6 +135,7 @@ $z-indexes:(
   $search-icon-color,
   $https-icon-color,
   $pause-icon-color,
+  $regexp-icon-color,
   $color,
   $tool-menu-hover-background
 ) {
@@ -182,6 +183,12 @@ $z-indexes:(
         background-image: url(/img/pause_19x19_#{$icon-color}.webp);
         &.pause {
           background-image: url(/img/pause_19x19_#{$pause-icon-color}.webp);
+        }
+      }
+      &.button_regexp {
+        background-image: url(/img/regexp_19x19_#{$icon-color}.webp);
+        &.regexp {
+          background-image: url(/img/regexp_19x19_#{$regexp-icon-color}.webp);
         }
       }
       &.button_tool {
@@ -422,6 +429,7 @@ $z-indexes:(
       $search-icon-color: "777",
       $https-icon-color: "182",
       $pause-icon-color: "811",
+      $regexp-icon-color: "06e",
       $color: #111,
       $tool-menu-hover-background: hsl(210, 50%, 95%)
     );
@@ -442,6 +450,7 @@ $z-indexes:(
       $search-icon-color: "aaa",
       $https-icon-color: "3a5",
       $pause-icon-color: "a33",
+      $regexp-icon-color: "f93",
       $color: #eee,
       $tool-menu-hover-background: hsl(30, 100%, 40%)
     );

--- a/src/image/svg/regexp.svg
+++ b/src/image/svg/regexp.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+  <rect x="60" y="60" width="380" height="380" style="" rx="55" ry="55" fill="none" stroke="#333" stroke-width="20"/>
+  <text style="font-size: 320px; font-weight: 700; white-space: pre;" x="130" y="360" fill="#333">R</text>
+</svg>

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -466,6 +466,7 @@ class app.view.TabContentView extends app.view.PaneContentView
     @_setupSortItemSelector()
     @_setupSchemeButton()
     @_setupAutoReload()
+    @_setupRegExpButton()
     @_setupToolMenu()
     return
 
@@ -737,6 +738,30 @@ class app.view.TabContentView extends app.view.PaneContentView
 
     window.on("view_unload", ->
       clearInterval(autoLoadInterval)
+      return
+    )
+    return
+
+  ###*
+  @method _setupRegExpButton
+  @private
+  ###
+  _setupRegExpButton: ->
+    $button = @$element.C("button_regexp")[0]
+
+    return unless $button
+    unless @$element.hasClass("view_thread")
+      $button.remove() if $button
+      return
+
+    if @$element.hasClass("search_regexp")
+      $button.addClass("regexp")
+    else
+      $button.removeClass("regexp")
+
+    $button.on("click", =>
+      $button.toggleClass("regexp")
+      @$element.dispatchEvent(new Event("change_search_regexp"))
       return
     )
     return

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -856,8 +856,9 @@ app.boot("/view/thread.html", ->
         $content.addClass("searching")
         for dom in $content.child()
           if (
-            (searchRegExp and searchRegExp.test(dom.textContent)) or
-            app.util.normalize(dom.textContent).includes(query)
+            ((searchRegExp and searchRegExp.test(dom.textContent)) or
+             app.util.normalize(dom.textContent).includes(query)) and
+            (!dom.hasClass("ng") or dom.hasClass("disp_ng"))
           )
             dom.addClass("search_hit")
             hitCount++

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -811,10 +811,17 @@ app.boot("/view/thread.html", ->
     )
     return
 
+  # 検索モードの切り替え
+  $view.on("change_search_regexp", ->
+    $content.toggleClass("search_regexp")
+    return
+  )
+
   #検索ボックス
   do ->
     searchStoredScrollTop = null
     $searchbox = $view.C("searchbox")[0]
+    searchRegExpEnter = false
 
     $searchbox.on("compositionend", ->
       @dispatchEvent(new Event("input"))
@@ -822,6 +829,20 @@ app.boot("/view/thread.html", ->
     )
     $searchbox.on("input", ({isComposing}) ->
       return if isComposing
+      searchRegExpMode = $content.hasClass("search_regexp")
+      return if searchRegExpMode and !searchRegExpEnter
+      searchRegExpEnter = false
+      searchRegExp = null
+      if searchRegExpMode and @value isnt ""
+        try
+          searchRegExp = new RegExp(@value, "i")
+        catch e
+          app.message.send("notify",
+            message: "正規表現が正しくありません。"
+            background_color: "red"
+          )
+          return
+
       $content.dispatchEvent(new Event("searchstart"))
       if @value isnt ""
         if typeof searchStoredScrollTop isnt "number"
@@ -834,7 +855,10 @@ app.boot("/view/thread.html", ->
 
         $content.addClass("searching")
         for dom in $content.child()
-          if app.util.normalize(dom.textContent).includes(query)
+          if (
+            (searchRegExp and searchRegExp.test(dom.textContent)) or
+            app.util.normalize(dom.textContent).includes(query)
+          )
             dom.addClass("search_hit")
             hitCount++
           else
@@ -858,7 +882,13 @@ app.boot("/view/thread.html", ->
       return
     )
 
-    $searchbox.on("keyup", ({which}) ->
+    $searchbox.on("keydown", ({which}) ->
+      if $content.hasClass("search_regexp")
+        if which is 13 or which is 27 # Enter|Esc
+          @value = "" if which is 27
+          searchRegExpEnter = true
+          @dispatchEvent(new Event("input"))
+        return
       if which is 27 #Esc
         if @value isnt ""
           @value = ""

--- a/src/view/thread.pug
+++ b/src/view/thread.pug
@@ -13,6 +13,7 @@ block vars
 block body
   .message_bar
   nav.nav_bar
+    .button.button_regexp(title="正規表現で検索")
     label
       input.searchbox(type="search" placeholder="検索")
       span.hit_count


### PR DESCRIPTION
スレ内検索で正規表現を使用可能にしてみました。大文字小文字の違いは無視します。
ボタンのイメージについては、フォントを指定するとファイルが巨大になるためにフォントを指定していませんので、ビルド環境によっては座標などの微調整が必要になるかもしれません。