### PR TITLE
Update: AAの縮小表示 refs #162+α

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@
 
 namespace app {
   type logLevel = "log" | "debug" | "info" | "warn" | "error";
-  var logLevels: logLevel[] = ["log", "debug", "info", "warn", "error"];
+  var logLevels = <Set<logLevel>>new Set(["log", "debug", "info", "warn", "error"]);
 
   export function criticalError (message:string):void {
     new Notification(
@@ -18,8 +18,8 @@ namespace app {
   }
 
   export function log (level:logLevel, ...data:any[]) {
-    if (logLevels.includes(level)) {
-      console[<string>level](...data);
+    if (logLevels.has(level)) {
+      console[level](...data);
     }
     else {
       log("error", "app.log: 引数levelが不正な値です", level);
@@ -33,12 +33,7 @@ namespace app {
       return src;
     }
 
-    if (Array.isArray(src)) {
-      copy = [];
-    }
-    else {
-      copy = {};
-    }
+    copy = Array.isArray(src) ? [] : {};
 
     for (key in src) {
       copy[key] = deepCopy(src[key]);

--- a/src/app.ts
+++ b/src/app.ts
@@ -220,6 +220,7 @@ namespace app {
       ["expand_short_url", "none"],
       ["expand_short_url_timeout", "3000"],
       ["aa_font", "aa"],
+      ["aa_min_ratio", "40"],
       ["popup_trigger", "click"],
       ["popup_delay_time", "0"],
       ["ngwords", "Title: 5ちゃんねるへようこそ\nTitle:【新着情報】5chブラウザがやってきた！"],

--- a/src/core/Board.coffee
+++ b/src/core/Board.coffee
@@ -237,7 +237,7 @@ class app.Board
       )
 
     if bbsType is "jbbs"
-      board.splice(-1, 1)
+      board.pop()
 
     if board.length > 0
       return board

--- a/src/core/ImageReplaceDat.coffee
+++ b/src/core/ImageReplaceDat.coffee
@@ -5,8 +5,8 @@
 ###
 class app.ImageReplaceDat
   _dat = null
-  _configName = "image_replace_dat_obj"
-  _configStringName = "image_replace_dat"
+  _CONFIG_NAME = "image_replace_dat_obj"
+  _CONFIG_STRING_NAME = "image_replace_dat"
   _INVALID_URL = "invalid://invalid"
 
   #jsonには正規表現のオブジェクトが含めれないので
@@ -28,14 +28,14 @@ class app.ImageReplaceDat
 
   _config =
     get: ->
-      return JSON.parse(app.config.get(_configName))
+      return JSON.parse(app.config.get(_CONFIG_NAME))
     set: (str) ->
-      app.config.set(_configName, JSON.stringify(str))
+      app.config.set(_CONFIG_NAME, JSON.stringify(str))
       return
     getString: ->
-      return app.config.get(_configStringName)
+      return app.config.get(_CONFIG_STRING_NAME)
     setString: (str) ->
-      app.config.set(_configStringName, str)
+      app.config.set(_CONFIG_STRING_NAME, str)
       return
 
   ###*

--- a/src/core/ImageReplaceDat.coffee
+++ b/src/core/ImageReplaceDat.coffee
@@ -15,14 +15,14 @@ class app.ImageReplaceDat
     for d from _dat
       try
         d.baseUrlReg = new RegExp(d.baseUrl, "i")
-      catch e
-        app.message.send "notify", {
+      catch
+        app.message.send("notify",
           message: """
             ImageViewURLReplace.datの一致URLの正規表現(#{d.baseUrl})を読み込むのに失敗しました
             この行は無効化されます
           """
           background_color: "red"
-        }
+        )
         d.baseUrl = _INVALID_URL
     return
 
@@ -43,7 +43,7 @@ class app.ImageReplaceDat
   @return {Object}
   ###
   @get: ->
-    if !_dat?
+    unless _dat?
       _dat = new Set(_config.get())
       _setupReg()
     return _dat
@@ -89,7 +89,7 @@ class app.ImageReplaceDat
   ###
   @set: (string) ->
     _dat = @parse(string)
-    _config.set(Array.from(_dat))
+    _config.set([_dat...])
     _setupReg()
     return
 

--- a/src/core/NG.coffee
+++ b/src/core/NG.coffee
@@ -4,35 +4,37 @@
 @static
 ###
 class app.NG
-  @NG_TYPE_INVALID = "invalid"
-  @NG_TYPE_REG_EXP = "RegExp"
-  @NG_TYPE_REG_EXP_TITLE = "RegExpTitle"
-  @NG_TYPE_REG_EXP_NAME = "RegExpName"
-  @NG_TYPE_REG_EXP_MAIL = "RegExpMail"
-  @NG_TYPE_REG_EXP_ID = "RegExpId"
-  @NG_TYPE_REG_EXP_SLIP = "RegExpSlip"
-  @NG_TYPE_REG_EXP_BODY = "RegExpBody"
-  @NG_TYPE_REG_EXP_URL = "RegExpUrl"
-  @NG_TYPE_TITLE = "Title"
-  @NG_TYPE_NAME = "Name"
-  @NG_TYPE_MAIL = "Mail"
-  @NG_TYPE_ID = "ID"
-  @NG_TYPE_SLIP = "Slip"
-  @NG_TYPE_BODY = "Body"
-  @NG_TYPE_WORD = "Word"
-  @NG_TYPE_URL = "Url"
-  @NG_TYPE_AUTO = "Auto"
-  @NG_TYPE_AUTO_CHAIN = "Chain"
-  @NG_TYPE_AUTO_CHAIN_ID = "ChainID"
-  @NG_TYPE_AUTO_CHAIN_SLIP = "ChainSLIP"
-  @NG_TYPE_AUTO_NOTHING_ID = "NothingID"
-  @NG_TYPE_AUTO_NOTHING_SLIP = "NothingSLIP"
-  @NG_TYPE_AUTO_REPEAT_MESSAGE = "RepeatMessage"
-  @NG_TYPE_AUTO_FORWARD_LINK = "ForwardLink"
+  @TYPE =
+    INVALID: "invalid"
+    REG_EXP: "RegExp"
+    REG_EXP_TITLE: "RegExpTitle"
+    REG_EXP_NAME: "RegExpName"
+    REG_EXP_MAIL: "RegExpMail"
+    REG_EXP_ID: "RegExpId"
+    REG_EXP_SLIP: "RegExpSlip"
+    REG_EXP_BODY: "RegExpBody"
+    REG_EXP_URL: "RegExpUrl"
+    TITLE: "Title"
+    NAME: "Name"
+    MAIL: "Mail"
+    ID: "ID"
+    SLIP: "Slip"
+    BODY: "Body"
+    WORD: "Word"
+    URL: "Url"
+    AUTO: "Auto"
+    AUTO_CHAIN: "Chain"
+    AUTO_CHAIN_ID: "ChainID"
+    AUTO_CHAIN_SLIP: "ChainSLIP"
+    AUTO_NOTHING_ID: "NothingID"
+    AUTO_NOTHING_SLIP: "NothingSLIP"
+    AUTO_REPEAT_MESSAGE: "RepeatMessage"
+    AUTO_FORWARD_LINK: "ForwardLink"
+
+  _CONFIG_NAME = "ngobj"
+  _CONFIG_STRING_NAME = "ngwords"
 
   _ng = null
-  _configName = "ngobj"
-  _configStringName = "ngwords"
   _ignoreResRegNumber = /^ignoreResNumber:(\d+)(?:-?(\d+))?,(.*)$/
   _ignoreNgType = /^ignoreNgType:(?:\$\((.*?)\):)?(.*)$/
   _expireDate = /^expireDate:(\d{4}\/\d{1,2}\/\d{1,2}),(.*)$/
@@ -60,28 +62,28 @@ class app.NG
       convFlag = true
       if n.subElements?
         for subElement in n.subElements
-          continue unless subElement.type.startsWith(app.NG.NG_TYPE_REG_EXP)
+          continue unless subElement.type.startsWith(NG.TYPE.REG_EXP)
           subElement.reg = _convReg(subElement)
           unless subElement.reg
-            subElement.type = app.NG.NG_TYPE_INVALID
+            subElement.type = NG.TYPE.INVALID
             convFlag = false
             break
-      if convFlag and n.type.startsWith(app.NG.NG_TYPE_REG_EXP)
+      if convFlag and n.type.startsWith(NG.TYPE.REG_EXP)
         n.reg = _convReg(n)
         convFlag = false unless n.reg
-      n.type = app.NG.NG_TYPE_INVALID unless convFlag
+      n.type = NG.TYPE.INVALID unless convFlag
     return
 
   _config =
     get: ->
-      return JSON.parse(app.config.get(_configName))
+      return JSON.parse(app.config.get(_CONFIG_NAME))
     set: (str) ->
-      app.config.set(_configName, JSON.stringify(str))
+      app.config.set(_CONFIG_NAME, JSON.stringify(str))
       return
     getString: ->
-      return app.config.get(_configStringName)
+      return app.config.get(_CONFIG_STRING_NAME)
     setString: (str) ->
-      app.config.set(_configStringName, str)
+      app.config.set(_CONFIG_STRING_NAME, str)
       return
 
   ###*
@@ -112,52 +114,52 @@ class app.NG
       # キーワードごとのNG処理
       switch true
         when ngWord.startsWith("RegExp:")
-          ngElement.type = app.NG.NG_TYPE_REG_EXP
+          ngElement.type = NG.TYPE.REG_EXP
           ngElement.word = ngWord.substr(7)
         when ngWord.startsWith("RegExpTitle:")
-          ngElement.type = app.NG.NG_TYPE_REG_EXP_TITLE
+          ngElement.type = NG.TYPE.REG_EXP_TITLE
           ngElement.word = ngWord.substr(12)
         when ngWord.startsWith("RegExpName:")
-          ngElement.type = app.NG.NG_TYPE_REG_EXP_NAME
+          ngElement.type = NG.TYPE.REG_EXP_NAME
           ngElement.word = ngWord.substr(11)
         when ngWord.startsWith("RegExpMail:")
-          ngElement.type = app.NG.NG_TYPE_REG_EXP_MAIL
+          ngElement.type = NG.TYPE.REG_EXP_MAIL
           ngElement.word = ngWord.substr(11)
         when ngWord.startsWith("RegExpID:")
-          ngElement.type = app.NG.NG_TYPE_REG_EXP_ID
+          ngElement.type = NG.TYPE.REG_EXP_ID
           ngElement.word = ngWord.substr(9)
         when ngWord.startsWith("RegExpSlip:")
-          ngElement.type = app.NG.NG_TYPE_REG_EXP_SLIP
+          ngElement.type = NG.TYPE.REG_EXP_SLIP
           ngElement.word = ngWord.substr(11)
         when ngWord.startsWith("RegExpBody:")
-          ngElement.type = app.NG.NG_TYPE_REG_EXP_BODY
+          ngElement.type = NG.TYPE.REG_EXP_BODY
           ngElement.word = ngWord.substr(11)
         when ngWord.startsWith("RegExpUrl:")
-          ngElement.type = app.NG.NG_TYPE_REG_EXP_URL
+          ngElement.type = NG.TYPE.REG_EXP_URL
           ngElement.word = ngWord.substr(10)
         when ngWord.startsWith("Title:")
-          ngElement.type = app.NG.NG_TYPE_TITLE
+          ngElement.type = NG.TYPE.TITLE
           ngElement.word = app.util.normalize(ngWord.substr(6))
         when ngWord.startsWith("Name:")
-          ngElement.type = app.NG.NG_TYPE_NAME
+          ngElement.type = NG.TYPE.NAME
           ngElement.word = app.util.normalize(ngWord.substr(5))
         when ngWord.startsWith("Mail:")
-          ngElement.type = app.NG.NG_TYPE_MAIL
+          ngElement.type = NG.TYPE.MAIL
           ngElement.word = app.util.normalize(ngWord.substr(5))
         when ngWord.startsWith("ID:")
-          ngElement.type = app.NG.NG_TYPE_ID
+          ngElement.type = NG.TYPE.ID
           ngElement.word = ngWord
         when ngWord.startsWith("Slip:")
-          ngElement.type = app.NG.NG_TYPE_SLIP
+          ngElement.type = NG.TYPE.SLIP
           ngElement.word = ngWord.substr(5)
         when ngWord.startsWith("Body:")
-          ngElement.type = app.NG.NG_TYPE_BODY
+          ngElement.type = NG.TYPE.BODY
           ngElement.word = app.util.normalize(ngWord.substr(5))
         when ngWord.startsWith("Url:")
-          ngElement.type = app.NG.NG_TYPE_URL
+          ngElement.type = NG.TYPE.URL
           ngElement.word = ngWord.substr(4)
         when ngWord.startsWith("Auto:")
-          ngElement.type = app.NG.NG_TYPE_AUTO
+          ngElement.type = NG.TYPE.AUTO
           ngElement.word = ngWord.substr(5)
           if ngElement.word is ""
             ngElement.word = "*"
@@ -180,7 +182,7 @@ class app.NG
               for e in elm.subElements
                 ngElement.subElements.push(e)
         else
-          ngElement.type = app.NG.NG_TYPE_WORD
+          ngElement.type = NG.TYPE.WORD
           ngElement.word = app.util.normalize(ngWord)
       return ngElement
 
@@ -301,31 +303,31 @@ class app.NG
 
     _checkWord = (n) ->
       if (
-        (n.type is app.NG.NG_TYPE_REG_EXP and n.reg.test(tmpTxt1)) or
-        (n.type is app.NG.NG_TYPE_REG_EXP_NAME and n.reg.test(decodedName)) or
-        (n.type is app.NG.NG_TYPE_REG_EXP_MAIL and n.reg.test(decodedMail)) or
-        (n.type is app.NG.NG_TYPE_REG_EXP_ID and res.id? and n.reg.test(res.id)) or
-        (n.type is app.NG.NG_TYPE_REG_EXP_SLIP and res.slip? and n.reg.test(res.slip)) or
-        (n.type is app.NG.NG_TYPE_REG_EXP_BODY and n.reg.test(decodedMes)) or
-        (n.type is app.NG.NG_TYPE_REG_EXP_TITLE and n.reg.test(threadTitle)) or
-        (n.type is app.NG.NG_TYPE_REG_EXP_URL and n.reg.test(url)) or
-        (n.type is app.NG.NG_TYPE_TITLE and tmpTitle.includes(n.word)) or
-        (n.type is app.NG.NG_TYPE_NAME and app.util.normalize(decodedName).includes(n.word)) or
-        (n.type is app.NG.NG_TYPE_MAIL and app.util.normalize(decodedMail).includes(n.word)) or
-        (n.type is app.NG.NG_TYPE_ID and res.id?.includes(n.word)) or
-        (n.type is app.NG.NG_TYPE_SLIP and res.slip?.includes(n.word)) or
-        (n.type is app.NG.NG_TYPE_BODY and app.util.normalize(decodedMes).includes(n.word)) or
-        (n.type is app.NG.NG_TYPE_WORD and tmpTxt2.includes(n.word)) or
-        (n.type is app.NG.NG_TYPE_URL and url.includes(n.word))
+        (n.type is NG.TYPE.REG_EXP and n.reg.test(tmpTxt1)) or
+        (n.type is NG.TYPE.REG_EXP_NAME and n.reg.test(decodedName)) or
+        (n.type is NG.TYPE.REG_EXP_MAIL and n.reg.test(decodedMail)) or
+        (n.type is NG.TYPE.REG_EXP_ID and res.id? and n.reg.test(res.id)) or
+        (n.type is NG.TYPE.REG_EXP_SLIP and res.slip? and n.reg.test(res.slip)) or
+        (n.type is NG.TYPE.REG_EXP_BODY and n.reg.test(decodedMes)) or
+        (n.type is NG.TYPE.REG_EXP_TITLE and n.reg.test(threadTitle)) or
+        (n.type is NG.TYPE.REG_EXP_URL and n.reg.test(url)) or
+        (n.type is NG.TYPE.TITLE and tmpTitle.includes(n.word)) or
+        (n.type is NG.TYPE.NAME and app.util.normalize(decodedName).includes(n.word)) or
+        (n.type is NG.TYPE.MAIL and app.util.normalize(decodedMail).includes(n.word)) or
+        (n.type is NG.TYPE.ID and res.id?.includes(n.word)) or
+        (n.type is NG.TYPE.SLIP and res.slip?.includes(n.word)) or
+        (n.type is NG.TYPE.BODY and app.util.normalize(decodedMes).includes(n.word)) or
+        (n.type is NG.TYPE.WORD and tmpTxt2.includes(n.word)) or
+        (n.type is NG.TYPE.URL and url.includes(n.word))
       )
         return n.type
       return null
 
     for n from @get()
-      continue if n.type is app.NG.NG_TYPE_INVALID
+      continue if n.type is NG.TYPE.INVALID
       if isBoard
         # isNGBoard用の項目チェック
-        unless n.type in [app.NG.NG_TYPE_REG_EXP, app.NG.NG_TYPE_REG_EXP_TITLE, app.NG.NG_TYPE_TITLE, app.NG.NG_TYPE_WORD, app.NG.NG_TYPE_REG_EXP_URL, app.NG.NG_TYPE_URL]
+        unless n.type in [NG.TYPE.REG_EXP, NG.TYPE.REG_EXP_TITLE, NG.TYPE.TITLE, NG.TYPE.WORD, NG.TYPE.REG_EXP_URL, NG.TYPE.URL]
           continue
       else
         # ignoreResNumber用レス番号のチェック
@@ -361,9 +363,9 @@ class app.NG
   ###
   @isIgnoreResNumForAuto: (resNum, subType = "") ->
     for n from @get()
-      continue if n.type isnt app.NG.NG_TYPE_AUTO
       continue if n.subType? and (n.subType.indexOf(subType) is -1)
       if n.start? and ((n.finish? and n.start <= resNum and resNum <= n.finish) or (parseInt(n.start) is resNum))
+      continue if n.type isnt NG.TYPE.AUTO
         return true
     return false
 

--- a/src/core/ReplaceStrTxt.coffee
+++ b/src/core/ReplaceStrTxt.coffee
@@ -5,15 +5,21 @@
 ###
 class app.ReplaceStrTxt
   _replaceTable = null
-  _configName = "replace_str_txt_obj"
-  _configStringName = "replace_str_txt"
-  _urlPattern =
-    contain: 0
-    dontContain: 1
-    match: 2
-    dontMatch: 3
-    regex: 4
-    dontRegex: 5
+  _CONFIG_NAME = "replace_str_txt_obj"
+  _CONFIG_STRING_NAME = "replace_str_txt"
+  _URL_PATTERN =
+    CONTAIN: 0
+    DONTCONTAIN: 1
+    MATCH: 2
+    DONTMATCH: 3
+    REGEX: 4
+    DONTREGEX: 5
+  _PLACE_TABLE = new Map([
+    ["name", "name"]
+    ["mail", "mail"]
+    ["date", "other"]
+    ["msg", "message"]
+  ])
   _INVALID_BEFORE = "#^##invalid##^#"
   _INVALID_URL = "invalid://invalid"
 
@@ -39,7 +45,7 @@ class app.ReplaceStrTxt
         d.before = _INVALID_BEFORE
 
       try
-        if d.urlPattern is _urlPattern.regex or d.urlPattern is _urlPattern.dontRegex
+        if d.urlPattern in [_URL_PATTERN.REGEX, _URL_PATTERN.DONTREGEX]
           d.urlReg = new RegExp(d.url)
       catch e
         app.message.send "notify", {
@@ -54,14 +60,14 @@ class app.ReplaceStrTxt
 
   _config =
     get: ->
-      return JSON.parse(app.config.get(_configName))
+      return JSON.parse(app.config.get(_CONFIG_NAME))
     set: (str) ->
-      app.config.set(_configName, JSON.stringify(str))
+      app.config.set(_CONFIG_NAME, JSON.stringify(str))
       return
     getString: ->
-      return app.config.get(_configStringName)
+      return app.config.get(_CONFIG_STRING_NAME)
     setString: (str) ->
-      app.config.set(_configStringName, str)
+      app.config.set(_CONFIG_STRING_NAME, str)
       return
 
   ###*
@@ -125,13 +131,13 @@ class app.ReplaceStrTxt
       continue if d.before is _INVALID_BEFORE
       continue if d.url is _INVALID_URL
       if d.url?
-        if d.urlPattern is _urlPattern.contain or d.urlPattern is _urlPattern.dontContain
+        if d.urlPattern is _URL_PATTERN.CONTAIN or d.urlPattern is _URL_PATTERN.DONTCONTAIN
           flag = (url.includes(d.url) or title.includes(d.url))
-        else if d.urlPattern is _urlPattern.match or d.urlPattern is _urlPattern.dontMatch
+        else if d.urlPattern is _URL_PATTERN.MATCH or d.urlPattern is _URL_PATTERN.DONTMATCH
           flag = (url is d.url or title is d.url)
         if (
-          ((d.urlPattern is _urlPattern.contain or d.urlPattern is _urlPattern.match) and !flag) or
-          ((d.urlPattern is _urlPattern.dontContain or d.urlPattern is _urlPattern.dontMatch) and flag)
+          ((d.urlPattern is _URL_PATTERN.CONTAIN or d.urlPattern is _URL_PATTERN.MATCH) and !flag) or
+          ((d.urlPattern is _URL_PATTERN.DONTCONTAIN or d.urlPattern is _URL_PATTERN.DONTMATCH) and flag)
         )
           continue
       if d.type is "ex2"

--- a/src/core/ReplaceStrTxt.coffee
+++ b/src/core/ReplaceStrTxt.coffee
@@ -28,33 +28,34 @@ class app.ReplaceStrTxt
   _setupReg = () ->
     for d from _replaceTable
       try
-        if d.type is "rx"
-          d.beforeReg = new RegExp(d.before, "g")
-        else if d.type is "rx2"
-          d.beforeReg = new RegExp(d.before, "ig")
-        else if d.type is "ex"
-          d.beforeReg = new RegExp(d.before.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&"), "ig")
-      catch e
-        app.message.send "notify", {
+        d.beforeReg = switch d.type
+          when "rx"
+            new RegExp(d.before, "g")
+          when "rx2"
+            new RegExp(d.before, "ig")
+          when "ex"
+            new RegExp(d.before.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&"), "ig")
+      catch
+        app.message.send("notify",
           message: """
             ReplaceStr.txtの置換対象正規表現(#{d.before})を読み込むのに失敗しました
             この行は無効化されます
           """
           background_color: "red"
-        }
+        )
         d.before = _INVALID_BEFORE
 
       try
         if d.urlPattern in [_URL_PATTERN.REGEX, _URL_PATTERN.DONTREGEX]
           d.urlReg = new RegExp(d.url)
-      catch e
-        app.message.send "notify", {
+      catch
+        app.message.send("notify",
           message: """
             ReplaceStr.txtの対象URL/タイトル正規表現(#{d.url})を読み込むのに失敗しました
             この行は無効化されます
           """
           background_color: "red"
-        }
+        )
         d.url = _INVALID_URL
     return
 
@@ -75,7 +76,7 @@ class app.ReplaceStrTxt
   @return {Object}
   ###
   @get: ->
-    if !_replaceTable?
+    unless _replaceTable?
       _replaceTable = new Set(_config.get())
       _setupReg()
     return _replaceTable
@@ -87,27 +88,27 @@ class app.ReplaceStrTxt
   ###
   @parse: (string) ->
     replaceTable = new Set()
-    if string isnt ""
-      replaceStrSplit = string.split("\n")
-      for r in replaceStrSplit
-        continue if r is ""
-        continue if ["//",";", "'"].some((ele) -> r.startsWith(ele))
-        s = /(?:<(\w{2,3})>)?(.*)\t(.+)\t(name|mail|date|msg|all)(?:\t(?:<(\d)>)?(.+))?/.exec(r)
-        if s?
-          obj =
-            type: s[1] ? "ex"
-            place: s[4]
-            before: s[2]
-            after: s[3]
-            urlPattern: s[5]
-            url: s[6]
-          if obj.type is ""
-            obj.type = "rx"
-          if obj.place is ""
-            obj.place = "all"
-          if s[6]? and !s[5]?
-            obj.urlPattern = 0
-          replaceTable.add(obj)
+    return replaceTable if string is ""
+    replaceStrSplit = string.split("\n")
+    for r in replaceStrSplit
+      continue if r is ""
+      continue if ["//",";", "'"].some((ele) -> r.startsWith(ele))
+      s = /(?:<(\w{2,3})>)?(.*)\t(.+)\t(name|mail|date|msg|all)(?:\t(?:<(\d)>)?(.+))?/.exec(r)
+      continue unless s?
+      obj =
+        type: s[1] ? "ex"
+        place: s[4]
+        before: s[2]
+        after: s[3]
+        urlPattern: s[5]
+        url: s[6]
+      if obj.type is ""
+        obj.type = "rx"
+      if obj.place is ""
+        obj.place = "all"
+      if s[6]? and !s[5]?
+        obj.urlPattern = 0
+      replaceTable.add(obj)
     return replaceTable
 
   ###*
@@ -116,7 +117,7 @@ class app.ReplaceStrTxt
   ###
   @set: (string) ->
     _replaceTable = @parse(string)
-    _config.set(Array.from(_replaceTable))
+    _config.set([_replaceTable...])
     _setupReg()
     return
 
@@ -131,32 +132,24 @@ class app.ReplaceStrTxt
       continue if d.before is _INVALID_BEFORE
       continue if d.url is _INVALID_URL
       if d.url?
-        if d.urlPattern is _URL_PATTERN.CONTAIN or d.urlPattern is _URL_PATTERN.DONTCONTAIN
+        if d.urlPattern in [_URL_PATTERN.CONTAIN, _URL_PATTERN.DONTCONTAIN]
           flag = (url.includes(d.url) or title.includes(d.url))
-        else if d.urlPattern is _URL_PATTERN.MATCH or d.urlPattern is _URL_PATTERN.DONTMATCH
-          flag = (url is d.url or title is d.url)
-        if (
-          ((d.urlPattern is _URL_PATTERN.CONTAIN or d.urlPattern is _URL_PATTERN.MATCH) and !flag) or
-          ((d.urlPattern is _URL_PATTERN.DONTCONTAIN or d.urlPattern is _URL_PATTERN.DONTMATCH) and flag)
-        )
-          continue
+        else if d.urlPattern in [_URL_PATTERN.MATCH, _URL_PATTERN.DONTMATCH]
+          flag = (d.url in [url, title])
+        if d.urlPattern in [_URL_PATTERN.DONTCONTAIN, _URL_PATTERN.DONTMATCH]
+          flag = !flag
+        continue unless flag
       if d.type is "ex2"
         before = d.before
       else
         before = d.beforeReg
-      switch d.place
-        when "name"
-          res.name = res.name.replace(before, d.after)
-        when "mail"
-          res.mail = res.mail.replace(before, d.after)
-        when "date"
-          res.other = res.other.replace(before, d.after)
-        when "msg"
-          res.message = res.message.replace(before, d.after)
-        when "all"
-          res =
-            name: res.name.replace(before, d.after)
-            mail: res.mail.replace(before, d.after)
-            other: res.other.replace(before, d.after)
-            message: res.message.replace(before, d.after)
+      if d.place is "all"
+        res =
+          name: res.name.replace(before, d.after)
+          mail: res.mail.replace(before, d.after)
+          other: res.other.replace(before, d.after)
+          message: res.message.replace(before, d.after)
+      else
+        place = _PLACE_TABLE.get(d.place)
+        res[place] = res[place].replace(before, d.after)
     return res

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -107,7 +107,7 @@ class app.Thread
                 thread = threadCache
               else
                 if readcgiVer < 6
-                  threadResponse.res.splice(0, 1)
+                  threadResponse.res.shift()
                 thread = threadResponse
                 thread.res = threadCache.res.concat(threadResponse.res)
           else

--- a/src/ui/AANoOverflow.coffee
+++ b/src/ui/AANoOverflow.coffee
@@ -1,0 +1,64 @@
+window.UI ?= {}
+
+class UI.AANoOverflow
+  _AA_CLASS_NAME = "aa"
+  _MINI_AA_CLASS_NAME = "mini_aa"
+  _SCROLL_AA_CLASS_NAME = "scroll_aa"
+
+  # minRatioはパーセント
+  constructor: (@$view, {@minRatio = 40, @maxFont = 16} = {}) ->
+    if @minRatio >= 100
+      return
+    @canvasEle = $__("canvas")
+    @ctx = @canvasEle.getContext("2d")
+    @ctx.font = @maxFont+'px "MS PGothic", "IPAMonaPGothic", "Konatu", "Monapo", "Textar"'
+
+    @$view.on("view_loaded", =>
+      @_setFontSizes()
+      return
+    )
+    # Todo: observe resize
+    return
+
+  _getStrLength: (str) ->
+    # canvas上での幅(おそらくhtml上でも同様)
+    return @ctx.measureText(str).width
+
+  _setFontSize: ($article, width) ->
+    $message = $article.C("message")[0]
+    charCountInLine = $message.innerText.split("\n").map(@_getStrLength.bind(@))
+    textMaxWidth = Math.max(charCountInLine...)
+
+    # リセット
+    $message.removeClass(_MINI_AA_CLASS_NAME)
+    $message.removeClass(_SCROLL_AA_CLASS_NAME)
+    $message.style.transform = ""
+    $message.style.width = ""
+    $message.style["margin-bottom"] = ""
+
+    return if width > textMaxWidth
+
+    ratio = width/textMaxWidth
+    ratio = Math.floor(ratio*100)/100
+    if ratio < @minRatio/100
+      ratio = @minRatio/100
+      $message.addClass(_SCROLL_AA_CLASS_NAME)
+      $message.style.width = "#{width / ratio}px"
+
+    $message.addClass(_MINI_AA_CLASS_NAME)
+
+    heightOld = $message.clientHeight
+
+    $message.style.transform = "scale(#{ratio})"
+    $message.style["margin-bottom"] = "#{-(1-ratio) * heightOld}px"
+    return
+
+  _setFontSizes: ->
+    $aaArticles = @$view.C("content")[0].C(_AA_CLASS_NAME)
+    return unless $aaArticles.length > 0
+
+    # レスの幅はすべて同じと考える
+    width = @$view.C("content")[0].C("message")[0].clientWidth
+    for $article from $aaArticles
+      @_setFontSize($article, width)
+    return

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -169,13 +169,14 @@ class UI.ThreadContent
       )
       @findHarmfulFlag = false
 
-    @container.on "scrollstart", =>
+    @container.on("scrollstart", =>
       @_isScrolling = true
       return
-
-    @container.on "scrollfinish", =>
+    )
+    @container.on("scrollfinish", =>
       @_isScrolling = false
       return
+    )
 
     return
 
@@ -1034,20 +1035,27 @@ class UI.ThreadContent
       return ngObj
 
     if bbsType is "2ch"
+      judgementIdType = app.config.get("how_to_judgment_id")
       # idなしをNG
       if (
-        app.config.isOn("nothing_id_ng") and !objRes.id? and
-        ((app.config.get("how_to_judgment_id") is "first_res" and @_existIdAtFirstRes) or
-         (app.config.get("how_to_judgment_id") is "exists_once" and @idIndex.size isnt 0)) and
+        app.config.isOn("nothing_id_ng") and
+        !objRes.id? and
+        (
+          (judgementIdType is "first_res" and @_existIdAtFirstRes) or
+          (judgementIdType is "exists_once" and @idIndex.size isnt 0)
+        ) and
         !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_NOTHING_ID) and
         !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_NOTHING_ID)
       )
         return {type: app.NG.TYPE.AUTO_NOTHING_ID}
       # slipなしをNG
       if (
-        app.config.isOn("nothing_slip_ng") and !objRes.slip? and
-        ((app.config.get("how_to_judgment_id") is "first_res" and @_existSlipAtFirstRes) or
-         (app.config.get("how_to_judgment_id") is "exists_once" and @slipIndex.size isnt 0)) and
+        app.config.isOn("nothing_slip_ng") and
+        !objRes.slip? and
+        (
+          (judgementIdType is "first_res" and @_existSlipAtFirstRes) or
+          (judgementIdType is "exists_once" and @slipIndex.size isnt 0)
+        ) and
         !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_NOTHING_SLIP) and
         !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_NOTHING_SLIP)
       )
@@ -1340,16 +1348,14 @@ class UI.ThreadContent
   @param {Element} $res
   ###
   addWriteHistory: ($res) ->
-    name = $res.C("name")[0].textContent
-    mail = $res.C("mail")[0].textContent
     date = app.util.stringToDate($res.C("other")[0].textContent).valueOf()
     if date?
       app.WriteHistory.add({
         url: @url
         res: parseInt($res.C("num")[0].textContent)
         title: document.title
-        name
-        mail
+        name: $res.C("name")[0].textContent
+        mail: $res.C("mail")[0].textContent
         message: $res.C("message")[0].textContent
         date
       })

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -941,9 +941,9 @@ class UI.ThreadContent
       getRes = @container.child()[r - 1]
       continue if getRes.hasClass("ng")
       rn = +getRes.C("num")[0].textContent
-      continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.NG_TYPE_AUTO_CHAIN)
-      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.NG_TYPE_AUTO_CHAIN)
-      @setNG(getRes, app.NG.NG_TYPE_AUTO_CHAIN)
+      continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.TYPE.AUTO_CHAIN)
+      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN)
+      @setNG(getRes, app.NG.TYPE.AUTO_CHAIN)
       # NG連鎖IDの登録
       if app.config.isOn("chain_ng_id") and app.config.isOn("chain_ng_id_by_chain")
         if id = getRes.getAttr("data-id")
@@ -967,9 +967,9 @@ class UI.ThreadContent
     for r in @container.$$("article[data-id=\"#{id}\"]")
       continue if r.hasClass("ng")
       rn = +r.C("num")[0].textContent
-      continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.NG_TYPE_AUTO_CHAIN_ID)
-      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.NG_TYPE_AUTO_CHAIN_ID)
-      @setNG(r, app.NG.NG_TYPE_AUTO_CHAIN_ID)
+      continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.TYPE.AUTO_CHAIN_ID)
+      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_ID)
+      @setNG(r, app.NG.TYPE.AUTO_CHAIN_ID)
       # 連鎖NG
       @_chainNG(r) if app.config.isOn("chain_ng")
     return
@@ -984,9 +984,9 @@ class UI.ThreadContent
     for r in @container.$$("article[data-slip=\"#{slip}\"]")
       continue if r.hasClass("ng")
       rn = +r.C("num")[0].textContent
-      continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.NG_TYPE_AUTO_CHAIN_SLIP)
-      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.NG_TYPE_AUTO_CHAIN_SLIP)
-      @setNG(r, app.NG.NG_TYPE_AUTO_CHAIN_SLIP)
+      continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.TYPE.AUTO_CHAIN_SLIP)
+      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_SLIP)
+      @setNG(r, app.NG.TYPE.AUTO_CHAIN_SLIP)
       # 連鎖NG
       @_chainNG(r) if app.config.isOn("chain_ng")
     return
@@ -1004,14 +1004,14 @@ class UI.ThreadContent
       if (
         app.config.isOn("chain_ng_id") and
         objRes.id? and
-        not (ngObj.type in [app.NG.NG_TYPE_ID, app.NG.NG_TYPE_AUTO_CHAIN_ID])
+        not (ngObj.type in [app.NG.TYPE.ID, app.NG.TYPE.AUTO_CHAIN_ID])
       )
         @_ngIdForChain.add(objRes.id) unless @_ngIdForChain.has(objRes.id)
       # NG連鎖SLIPの登録
       if (
         app.config.isOn("chain_ng_slip") and
         objRes.slip? and
-        not (ngObj.type in [app.NG.NG_TYPE_SLIP, app.NG.NG_TYPE_AUTO_CHAIN_SLIP])
+        not (ngObj.type in [app.NG.TYPE.SLIP, app.NG.TYPE.AUTO_CHAIN_SLIP])
       )
         @_ngSlipForChain.add(objRes.slip) unless @_ngSlipForChain.has(objRes.slip)
     return ngObj
@@ -1039,38 +1039,38 @@ class UI.ThreadContent
         app.config.isOn("nothing_id_ng") and !objRes.id? and
         ((app.config.get("how_to_judgment_id") is "first_res" and @_existIdAtFirstRes) or
          (app.config.get("how_to_judgment_id") is "exists_once" and @idIndex.size isnt 0)) and
-        !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.NG_TYPE_AUTO_NOTHING_ID) and
-        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.NG_TYPE_AUTO_NOTHING_ID)
+        !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_NOTHING_ID) and
+        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_NOTHING_ID)
       )
-        return {type: app.NG.NG_TYPE_AUTO_NOTHING_ID}
+        return {type: app.NG.TYPE.AUTO_NOTHING_ID}
       # slipなしをNG
       if (
         app.config.isOn("nothing_slip_ng") and !objRes.slip? and
         ((app.config.get("how_to_judgment_id") is "first_res" and @_existSlipAtFirstRes) or
          (app.config.get("how_to_judgment_id") is "exists_once" and @slipIndex.size isnt 0)) and
-        !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.NG_TYPE_AUTO_NOTHING_SLIP) and
-        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.NG_TYPE_AUTO_NOTHING_SLIP)
+        !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_NOTHING_SLIP) and
+        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_NOTHING_SLIP)
       )
-        return {type: app.NG.NG_TYPE_AUTO_NOTHING_SLIP}
+        return {type: app.NG.TYPE.AUTO_NOTHING_SLIP}
 
     # 連鎖IDのNG
     if (
       app.config.isOn("chain_ng_id") and
       objRes.id? and
       @_ngIdForChain.has(objRes.id) and
-      !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.NG_TYPE_AUTO_CHAIN_ID) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.NG_TYPE_AUTO_CHAIN_ID)
+      !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_CHAIN_ID) and
+      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_ID)
     )
-      return {type: app.NG.NG_TYPE_AUTO_CHAIN_ID}
+      return {type: app.NG.TYPE.AUTO_CHAIN_ID}
     # 連鎖SLIPのNG
     if (
       app.config.isOn("chain_ng_slip") and
       objRes.slip? and
       @_ngSlipForChain.has(objRes.slip) and
-      !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.NG_TYPE_AUTO_CHAIN_SLIP) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.NG_TYPE_AUTO_CHAIN_SLIP)
+      !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_CHAIN_SLIP) and
+      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_SLIP)
     )
-      return {type: app.NG.NG_TYPE_AUTO_CHAIN_SLIP}
+      return {type: app.NG.TYPE.AUTO_CHAIN_SLIP}
 
     # 連投レスをNG
     if app.config.get("repeat_message_ng_count") > 1
@@ -1092,16 +1092,16 @@ class UI.ThreadContent
       @_resMessageMap.get(resMessage).add(objRes.num)
       if (
         @_resMessageMap.get(resMessage).size >= +app.config.get("repeat_message_ng_count") and
-        !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.NG_TYPE_AUTO_REPEAT_MESSAGE) and
-        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.NG_TYPE_AUTO_REPEAT_MESSAGE)
+        !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_REPEAT_MESSAGE) and
+        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_REPEAT_MESSAGE)
       )
-        return {type: app.NG.NG_TYPE_AUTO_REPEAT_MESSAGE}
+        return {type: app.NG.TYPE.AUTO_REPEAT_MESSAGE}
 
     # 前方参照をNG
     if (
       app.config.isOn("forward_link_ng") and
-      !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.NG_TYPE_AUTO_FORWARD_LINK) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.NG_TYPE_AUTO_FORWARD_LINK)
+      !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_FORWARD_LINK) and
+      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_FORWARD_LINK)
     )
       ngFlag = false
       resMessage = (
@@ -1122,7 +1122,7 @@ class UI.ThreadContent
               target++
             break if ngFlag
           break if ngFlag
-      return {type: app.NG.NG_TYPE_AUTO_FORWARD_LINK} if ngFlag
+      return {type: app.NG.TYPE.AUTO_FORWARD_LINK} if ngFlag
 
     return null
 

--- a/src/view/config.pug
+++ b/src/view/config.pug
@@ -91,6 +91,14 @@ block body
               |通常の文章と同じフォントで表示
 
         section
+          h2 アスキーアートの縮小表示の最小値
+          div
+            label
+              input.direct(name="aa_min_ratio" type="range" min="1" max="100")
+              span.aa_min_ratio_text
+              |% (100%のときは縮小表示しません)
+
+        section
           h2 2ch.netのスレッド読み込み形式
           div
             label

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -55,6 +55,7 @@ app.boot("/view/thread.html", ->
 
   if app.config.get("aa_font") is "aa"
     $content.addClass("config_use_aa_font")
+    new UI.AANoOverflow($view, {minRatio: app.config.get("aa_min_ratio")})
 
   write = (param = {}) ->
     param.url = viewUrl

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -163,6 +163,14 @@ header {
 
 .config_use_aa_font > .aa > .message {
   @include ascii-art;
+
+  &.mini_aa {
+    transform-origin: 0 0;
+    white-space: nowrap;
+  }
+  &.scroll_aa {
+    overflow-x: scroll;
+  }
 }
 
 .beicon[src="/img/loading.webp"] {


### PR DESCRIPTION
## Update: AAの縮小表示 refs #162
### 拡大縮小機能
 - `font-size`
   1. `font-size`はChrome側で最小10px(ユーザー依存)
   1. 最小値が取得できない かつ 小さくするためには対応が必要
 - `transform:scale()`
   1. そのまま拡大縮小するのでより`font-size/line-height: 16px/18px`に近くなる
   1. Chromeの仕様?バク?で余白が発生
 - `zoom`
   1. 拡大縮小で余白は発生せず
   1. 文字が荒く、再現度低

-> 実装: `transform:scale()`を使い、`margin-bottom`にマイナス値を入れることで余白は制御
  
### 横スクロール機能
AAが小さくなりすぎると文字が読めないので縮小する最小値を設定
縮小しても横幅が足りない場合、横スクロールができるように
  
## Fix: リファクタリング
 - 定数を大文字に&オブジェクトに
 - `Array::splice(0 or -1, 1)` -> `Array::pop()`, `Array::unshift()`
 - `Array.from(set)` -> `[set...]`
 - `delete` -> `= null`