### PR TITLE
Update: 板一覧更新後に板名取得テーブルが更新されるように close #447

### DIFF
--- a/src/core/BBSMenu.coffee
+++ b/src/core/BBSMenu.coffee
@@ -79,14 +79,15 @@ class app.BBSMenu
   @get: (forceReload = false) ->
     BBSMenu._updatingPromise = BBSMenu._update(forceReload) unless BBSMenu._updatingPromise?
     try
-      {menu} = await BBSMenu._updatingPromise
+      obj = await BBSMenu._updatingPromise
+      obj.status = "success"
       if forceReload
-        BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: {status: "success", menu}))
-    catch {menu, message}
+        BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: obj))
+    catch obj
+      obj.status = "error"
       if forceReload
-        BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: {status: "error", menu, message}))
-      throw {menu, message}
-    return {menu}
+        BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: obj))
+    return obj
 
   ###*
   @method parse

--- a/src/core/BBSMenu.coffee
+++ b/src/core/BBSMenu.coffee
@@ -80,9 +80,11 @@ class app.BBSMenu
     BBSMenu._updatingPromise = BBSMenu._update(forceReload) unless BBSMenu._updatingPromise?
     try
       {menu} = await BBSMenu._updatingPromise
-      BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: {status: "success", menu}))
+      if forceReload
+        BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: {status: "success", menu}))
     catch {menu, message}
-      BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: {status: "error", menu, message}))
+      if forceReload
+        BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: {status: "error", menu, message}))
       throw {menu, message}
     return {menu}
 

--- a/src/core/BoardTitleSolver.coffee
+++ b/src/core/BoardTitleSolver.coffee
@@ -11,14 +11,19 @@ class app.BoardTitleSolver
   @type Map | null
   ###
   @_bbsmenu: null
+  ###*
+  @property _bbsmenu
+  @private
+  @type Promise | null
+  ###
+  @_bbsmenuPromise: null
 
   ###*
-  @method getBBSMenu
+  @method _setupBBSMenu
   @return {Promise}
+  @private
   ###
-  @getBBSMenu: ->
-    return @_bbsmenu if @_bbsmenu?
-
+  @_setupBBSMenu: ->
     try
       {menu} = await app.BBSMenu.get()
     catch {menu, message}
@@ -36,6 +41,20 @@ class app.BoardTitleSolver
     for {board} in menu
       for {url, title} in board
         @_bbsmenu.set(app.URL.fix(url), title)
+    return
+
+  ###*
+  @method getBBSMenu
+  @return {Promise}
+  ###
+  @getBBSMenu: ->
+    return @_bbsmenu if @_bbsmenu?
+    if @_bbsmenuPromise?
+      await @_bbsmenuPromise
+    else
+      @_bbsmenuPromise = @_setupBBSMenu()
+      await @_bbsmenuPromise
+      @_bbsmenuPromise = null
     return @_bbsmenu
 
   ###*
@@ -145,7 +164,6 @@ class app.BoardTitleSolver
     return
 
 app.module("board_title_solver", [], (callback) ->
-  app.BoardTitleSolver.getBBSMenu()
   callback(app.BoardTitleSolver)
   return
 )

--- a/src/core/BoardTitleSolver.coffee
+++ b/src/core/BoardTitleSolver.coffee
@@ -48,17 +48,12 @@ class app.BoardTitleSolver
   @private
   ###
   @_setBBSMenu: ->
-    try
-      obj = await app.BBSMenu.get()
-      obj.status = "success"
-    catch obj
-      obj.status = "error"
-    finally
+    obj = await app.BBSMenu.get()
+    @_generateBBSMenu(obj)
+    app.BBSMenu.target.on("change", ({detail: obj}) =>
       @_generateBBSMenu(obj)
-      app.BBSMenu.target.on("change", ({detail: obj}) =>
-        @_generateBBSMenu(obj)
-        return
-      )
+      return
+    )
     return
 
   ###*

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -77,7 +77,7 @@ do ->
     #bbsmenuから検索
     unless newBoardUrl?
       newBoardUrl = do ->
-        {data} = await app.BBSMenu.get()
+        {menu: data} = await app.BBSMenu.get()
         unless data?
           throw new Error("BBSMenuの取得に失敗しました")
         match = oldBoardUrl.match(boardUrlReg)

--- a/src/view/sidemenu.coffee
+++ b/src/view/sidemenu.coffee
@@ -132,13 +132,8 @@ app.boot("/view/sidemenu.html", ["bbsmenu"], (BBSMenu) ->
     load = ->
       $view.addClass("loading")
       # 表示用板一覧の取得
-      try
-        obj = await BBSMenu.get()
-        obj.status = "success"
-      catch obj
-        obj.status = "error"
-      finally
-        setupDOM(obj)
+      obj = await BBSMenu.get()
+      setupDOM(obj)
       BBSMenu.target.on("change", ({detail: obj}) ->
         setupDOM(obj)
         return


### PR DESCRIPTION
Update: 板一覧更新後に板名取得テーブルが更新されるように close #447
Fix: 板名取得テーブルを複数回構築していたのを修正
Fix: 変更がない際に板一覧を構築し直さないように
Fix: 鯖移転先を板一覧から判定できていなかったのを修正
Fix: リファクタリング