### PR TITLE
Fix: 長大なスレでの負荷を軽減+α

### DIFF
--- a/src/common.scss
+++ b/src/common.scss
@@ -234,6 +234,7 @@ $z-indexes:(
     flex-flow: column;
   }
   .message_bar {
+    contain: layout;
     font-size: 13px;
     &.loading {
       padding: 3px;
@@ -244,6 +245,7 @@ $z-indexes:(
     }
   }
   .nav_bar {
+    contain: layout;
     height: 27px;
     border-bottom: 2px solid hsla(0, 0%, 0%, 0.2);
     z-index: var(--z-index-tabbed-view-nav-bar);

--- a/src/common.scss
+++ b/src/common.scss
@@ -490,16 +490,16 @@ $z-indexes:(
       width: 10em;
     }
     &.res, &.unread, &.written_res {
-      width: 4em;
+      width: 7ch;
     }
     &.heat {
-      width: 7em;
+      width: 9ch;
     }
     &.name, &.mail {
       width: 8em;
     }
     &.created_date, &.viewed_date, &.written_date {
-      width: 16em;
+      width: 18ch;
     }
   }
   tbody > tr {

--- a/src/common.scss
+++ b/src/common.scss
@@ -48,6 +48,7 @@ $z-indexes:(
 
   .command {
     position: fixed;
+    contain: strict;
     left: 0;
     right: 0;
     bottom: 0;

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -100,6 +100,7 @@ do ->
     return newBoardUrl
 
   #文字参照をデコード
+  $span = $__("span")
   app.util.decodeCharReference = (str) ->
     return str.replace(/\&(?:#(\d+)|#x([\dA-Fa-f]+)|([\da-zA-Z]+));/g, ($0, $1, $2, $3) ->
       #数値文字参照 - 10進数
@@ -110,7 +111,6 @@ do ->
         return String.fromCodePoint(parseInt($2, 16))
       #文字実体参照
       if $3?
-        $span = $__("span")
         $span.innerHTML = $0
         return $span.textContent
       return $0

--- a/src/cs_addlink.coffee
+++ b/src/cs_addlink.coffee
@@ -31,35 +31,33 @@ do ->
   )
 
   container = document.createElement("div")
-  style =
-    position: "fixed"
-    right: "10px"
-    top: "60px"
-    "background-color": "rgba(255,255,255,0.8)"
-    color: "#000"
-    border: "1px solid black"
-    "border-radius": "4px"
-    padding: "5px"
-    "font-size": "14px"
-    "font-weight": "normal"
-    "z-index": "255"
-
-  for key, val of style
-    container.style[key] = val
+  container.style.cssText = """
+    position: "fixed";
+    right: "10px";
+    top: "60px";
+    "background-color": "rgba(255,255,255,0.8)";
+    color: "#000";
+    border: "1px solid black";
+    "border-radius": "4px";
+    padding: "5px";
+    "font-size": "14px";
+    "font-weight": "normal";
+    "z-index": "255";
+    """
 
   openButton = document.createElement("span")
   openButton.id = openButtonId
   openButton.textContent = "read.crx 2 で開く"
-  openButton.style["cursor"] = "pointer"
-  openButton.style["text-decoration"] = "underline"
+  openButton.style.cursor = "pointer"
+  openButton.style.textDecoration = "underline"
   container.appendChild(openButton)
 
   closeButton = document.createElement("span")
   closeButton.id = closeButtonId
   closeButton.textContent = " x"
-  closeButton.style["cursor"] = "pointer"
-  closeButton.style["display"] = "inline-block"
-  closeButton.style["margin-left"] = "5px"
+  closeButton.style.cursor = "pointer"
+  closeButton.style.display = "inline-block"
+  closeButton.style.marginLeft = "5px"
   container.appendChild(closeButton)
 
   document.body.appendChild(container)

--- a/src/ui/AANoOverflow.coffee
+++ b/src/ui/AANoOverflow.coffee
@@ -31,9 +31,9 @@ class UI.AANoOverflow
 
     # リセット
     $message.removeClass(_MINI_AA_CLASS_NAME, _SCROLL_AA_CLASS_NAME)
-    $message.style.transform = ""
-    $message.style.width = ""
-    $message.style["margin-bottom"] = ""
+    $message.style.transform = null
+    $message.style.width = null
+    $message.style.marginBottom = null
 
     return if width > textMaxWidth
 
@@ -49,7 +49,7 @@ class UI.AANoOverflow
     heightOld = $message.clientHeight
 
     $message.style.transform = "scale(#{ratio})"
-    $message.style["margin-bottom"] = "#{-(1-ratio) * heightOld}px"
+    $message.style.marginBottom = "#{-(1-ratio) * heightOld}px"
     return
 
   _setFontSizes: ->

--- a/src/ui/AANoOverflow.coffee
+++ b/src/ui/AANoOverflow.coffee
@@ -61,3 +61,17 @@ class UI.AANoOverflow
     for $article from $aaArticles
       @_setFontSize($article, width)
     return
+
+  setMiniAA: ($article) ->
+    $article.addClass(_AA_CLASS_NAME)
+    @_setFontSize($article, $article.C("message")[0].clientWidth)
+    return
+
+  unsetMiniAA: ($article) ->
+    $article.removeClass(_AA_CLASS_NAME)
+    $message = $article.C("message")[0]
+    $message.removeClass(_MINI_AA_CLASS_NAME, _SCROLL_AA_CLASS_NAME)
+    $message.style.transform = null
+    $message.style.width = null
+    $message.style.marginBottom = null
+    return

--- a/src/ui/Animate.coffee
+++ b/src/ui/Animate.coffee
@@ -4,7 +4,7 @@ do ->
     e = ele.cloneNode(true)
     e.style.cssText = """
       height: auto;
-      width: #{ele.clientWidth};
+      width: #{ele.clientWidth}px;
       position: absolute;
       visibility: hidden;
       display: block;

--- a/src/ui/Animate.coffee
+++ b/src/ui/Animate.coffee
@@ -3,6 +3,7 @@ do ->
   getOriginHeight = (ele) ->
     e = ele.cloneNode(true)
     e.style.cssText = """
+      contain: content;
       height: auto;
       width: #{ele.clientWidth}px;
       position: absolute;

--- a/src/ui/ContextMenu.coffee
+++ b/src/ui/ContextMenu.coffee
@@ -44,7 +44,7 @@ do ->
       altParent.addClass("has_contextmenu")
 
     if window.innerWidth < $menu.offsetLeft + menuWidth
-      $menu.style.left = ""
+      $menu.style.left = null
       $menu.style.right = "1px"
     if window.innerHeight < $menu.offsetTop + $menu.offsetHeight
       $menu.style.top = "#{Math.max($menu.offsetTop - $menu.offsetHeight, 0)}px"

--- a/src/ui/ContextMenu.scss
+++ b/src/ui/ContextMenu.scss
@@ -1,5 +1,6 @@
 .contextmenu_menu {
   @include drop-shadow;
+  contain: content;
   display: flex;
   flex-flow: column nowrap;
   margin: 0;

--- a/src/ui/Dialog.scss
+++ b/src/ui/Dialog.scss
@@ -1,5 +1,6 @@
 .dialog_overlay {
   position: fixed;
+  contain: strict;
   left: 0;
   top: 0;
   width: 100%;

--- a/src/ui/PopupView.coffee
+++ b/src/ui/PopupView.coffee
@@ -349,5 +349,5 @@ class UI.PopupView
         @_popupMarginHeight += Math.abs(parseInt(tmp[2]))
         @_popupMarginHeight += Math.abs(parseInt(tmp[4]))
       outerHeight += @_popupMarginHeight
-    ele.style.zIndex = ""
+    ele.style.zIndex = null
     return outerHeight

--- a/src/ui/PopupView.coffee
+++ b/src/ui/PopupView.coffee
@@ -159,6 +159,9 @@ class UI.PopupView
 
     # 新規ノードの設定
     setupNewNode = (sourceNode, popupNode) =>
+      # CSSContainmentの恩恵を受けるために表示位置決定前にクラスを付加する
+      popupNode.addClass("popup")
+
       # 表示位置の決定
       setDispPosition(popupNode)
 
@@ -167,7 +170,6 @@ class UI.PopupView
       sourceNode.setAttr("stack-index", @_popupStack.length)
       sourceNode.on("mouseenter", @_onMouseEnter)
       sourceNode.on("mouseleave", @_onMouseLeave)
-      popupNode.addClass("popup")
       if app.config.get("aa_font") is "aa"
         popupNode.addClass("config_use_aa_font")
       popupNode.setAttr("stack-index", @_popupStack.length)

--- a/src/ui/Tab.scss
+++ b/src/ui/Tab.scss
@@ -5,6 +5,7 @@
 
 .tab_tabbar {
   display: flex;
+  contain: layout;
   flex-flow: wrap;
   margin: 0;
   padding: 0;
@@ -77,6 +78,7 @@
 }
 
 .tab_container {
+  contain: strict;
   flex-grow: 1;
   overflow: hidden;
   position: relative;

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -189,10 +189,9 @@ class UI.ThreadContent
     return
 
   ###*
-  @method _isHidden
-  @private
+  @method isHidden
   ###
-  _isHidden: (ele) ->
+  isHidden: (ele) ->
     unless @_hiddenSelectors?
       @_hiddenSelectors = []
       css = $$.I("user_css").sheet.cssRules
@@ -237,7 +236,7 @@ class UI.ThreadContent
     while (
       tmpTarget and
       (
-        (isHidden = @_isHidden(tmpTarget)) or
+        (isHidden = @isHidden(tmpTarget)) or
         tmpTarget.offsetTop + tmpTarget.offsetHeight > viewTop
       )
     )
@@ -248,7 +247,7 @@ class UI.ThreadContent
     while (
       tmpTarget and
       (
-        (isHidden = @_isHidden(tmpTarget)) or
+        (isHidden = @isHidden(tmpTarget)) or
         tmpTarget.offsetTop < viewBottom
       )
     )
@@ -297,16 +296,16 @@ class UI.ThreadContent
       target = null
 
     # もしターゲットがNGだった場合、その直前/直後の非NGレスをターゲットに変更する
-    if target and @_isHidden(target)
+    if target and @isHidden(target)
       replaced = target
       while (replaced = replaced.prev())
-        unless @_isHidden(replaced)
+        unless @isHidden(replaced)
           target = replaced
           break
         if !replaced?
           replaced = target
           while (replaced = replaced.next())
-            unless @_isHidden(replaced)
+            unless @isHidden(replaced)
               target = replaced
               break
 
@@ -479,7 +478,7 @@ class UI.ThreadContent
         if targetBottom <= containerHeight and target.next()
           target = target.next()
 
-          while target and @_isHidden(target)
+          while target and @isHidden(target)
             target = target.next()
 
         if not target
@@ -531,7 +530,7 @@ class UI.ThreadContent
         if 0 <= targetTop and target.prev()
           target = target.prev()
 
-          while target and @_isHidden(target)
+          while target and @isHidden(target)
             target = target.prev()
 
         if not target
@@ -765,7 +764,7 @@ class UI.ThreadContent
       $message.innerHTML = tmp
       $article.addLast($message)
 
-      $article.setClass(res.class...)
+      $article.setClass(res.class...) if res.class.length > 0
       $article.dataset.id = res.id if res.id?
       $article.dataset.slip = res.slip if res.slip?
       $article.dataset.trip = res.trip if res.trip?
@@ -1250,7 +1249,7 @@ class UI.ThreadContent
       thumbnail.style.height = "#{h}px"
 
     sib = sourceA
-    while true
+    loop
       pre = sib
       sib = pre.next()
       if !sib? or sib.tagName is "BR"
@@ -1286,7 +1285,7 @@ class UI.ThreadContent
       expandedURLLink = null
 
     sib = sourceA
-    while true
+    loop
       pre = sib
       sib = pre.next()
       if !sib? or sib.tagName is "BR"

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -79,11 +79,11 @@ class UI.ThreadList
     selector = {}
     column = {}
     i = 0
-    for key, j in Object.keys(keyToLabel) when key in option.th
+    for key, val of keyToLabel when key in option.th
       i++
       $th = $__("th")
       $th.setClass(key.replace(/([A-Z])/g, ($0, $1) -> "_" + $1.toLowerCase()))
-      $th.textContent = keyToLabel[key]
+      $th.textContent = val
       $tr.addLast($th)
       @_flg[key] = true
       selector[key] = "td:nth-child(#{i})"

--- a/src/view/board.scss
+++ b/src/view/board.scss
@@ -32,12 +32,17 @@ td {
   }
 }
 
+.content {
+  contain: strict;
+}
+
 tr.ng_thread {
   display: none;
 }
 
 .board_footer {
   position: absolute;
+  contain: content;
   bottom: 0;
   left: 0;
   right: 75px;

--- a/src/view/bookmark.scss
+++ b/src/view/bookmark.scss
@@ -64,6 +64,7 @@ td {
 
 .loading_overlay {
   position: fixed;
+  contain: content;
   top: initial;
   bottom: 0;
   height: initial;

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -471,7 +471,7 @@ app.main = ->
 
   app.message.on("notify", ({message: text, html, background_color = "#777"}) ->
     $div = $__("div")
-    $div.style["background-color"] = background_color
+    $div.style.backgroundColor = background_color
     $div2 = $__("div")
     if html?
       $div2.innerHTML = html

--- a/src/view/index.scss
+++ b/src/view/index.scss
@@ -22,6 +22,7 @@ iframe {
 }
 
 #body {
+  contain: strict;
   position: relative;
 }
 
@@ -111,6 +112,7 @@ iframe {
 }
 
 #modal {
+  contain: layout size;
   > iframe {
     z-index: var(--z-index-modal);
     position: fixed;
@@ -123,12 +125,14 @@ iframe {
 
 #app_notice_container {
   position: fixed;
+  contain: content;
   left: 50px;
   top: 10px;
   right: 50px;
   z-index: var(--z-index-notification);
   > div {
     @include drop-shadow;
+    contain: content;
     background-image: linear-gradient(transparent, rgba(black, 0.25));
     border-radius: 5px;
     color: #eeeeee;
@@ -162,6 +166,7 @@ iframe {
 }
 
 .keyboard_help {
+  contain: strict;
   z-index: var(--z-index-modalhelp);
   background: hsla(0, 0%, 0%, 0.9);
   color: hsl(0, 0%, 80%);

--- a/src/view/inputurl.scss
+++ b/src/view/inputurl.scss
@@ -33,6 +33,8 @@ input:first-child {
 
 input[type="submit"] {
   @include button;
+  padding: 0 5px;
+  height: initial;
 }
 
 .notice {

--- a/src/view/sidemenu.scss
+++ b/src/view/sidemenu.scss
@@ -13,6 +13,7 @@ body {
 }
 
 h3 {
+  contain: content;
   cursor: pointer;
   font: {
     size: inherit;
@@ -24,6 +25,7 @@ h3 {
 }
 
 ul {
+  contain: content;
   margin: 0;
   padding: 0;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -794,12 +794,6 @@ app.boot("/view/thread.html", ->
     )
     return
 
-  # 検索モードの切り替え
-  $view.on("change_search_regexp", ->
-    $content.toggleClass("search_regexp")
-    return
-  )
-
   #検索ボックス
   do ->
     searchStoredScrollTop = null
@@ -875,6 +869,13 @@ app.boot("/view/thread.html", ->
         if @value isnt ""
           @value = ""
           @dispatchEvent(new Event("input"))
+      return
+    )
+
+    # 検索モードの切り替え
+    $view.on("change_search_regexp", ->
+      $content.toggleClass("search_regexp")
+      $searchbox.dispatchEvent(new CustomEvent("input", detail: {isEnter: true}))
       return
     )
     return

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -49,7 +49,7 @@ app.boot("/view/thread.html", ->
 
   if app.config.get("aa_font") is "aa"
     $content.addClass("config_use_aa_font")
-    new UI.AANoOverflow($view, {minRatio: app.config.get("aa_min_ratio")})
+    AANoOverflow = new UI.AANoOverflow($view, {minRatio: app.config.get("aa_min_ratio")})
 
   write = (param = {}) ->
     param.url = viewUrl
@@ -369,7 +369,10 @@ app.boot("/view/thread.html", ->
       threadContent.removeClassWithOrg($res, "written")
 
     else if target.hasClass("toggle_aa_mode")
-      $res.toggleClass("aa")
+      if $res.hasClass("aa")
+        AANoOverflow.unsetMiniAA($res)
+      else
+        AANoOverflow.setMiniAA($res)
 
     else if target.hasClass("res_permalink")
       open(app.safeHref(viewUrl + $res.C("num")[0].textContent))

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -853,7 +853,8 @@ app.boot("/view/thread.html", ->
       else
         $content.removeClass("searching")
         $content.removeAttr("data-res-search-hit-count")
-        $view.C("search_hit")[0].removeClass("search_hit")
+        for dom in $view.C("search_hit") by -1
+          dom.removeClass("search_hit")
         $view.C("hit_count")[0].textContent = ""
 
         if typeof searchStoredScrollTop is "number"

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -1151,7 +1151,11 @@ app.viewThread._readStateManager = ($view) ->
     #onbeforeunload内で呼び出された時に、この値が0になる場合が有る
     return if received is 0
 
-    last = threadContent.getRead()
+    # 既読情報が存在しない場合readState.lastは0
+    if readState.last is 0
+      last = threadContent.getRead(1)
+    else
+      last = threadContent.getRead(readState.last)
 
     scanCountByReloaded++ if requestReloadFlag and !byScroll
 
@@ -1159,7 +1163,7 @@ app.viewThread._readStateManager = ($view) ->
       readState.received = received
       readStateUpdated = true
 
-    lastDisplay = threadContent.getDisplay()
+    lastDisplay = threadContent.getDisplay(last)
     if (
       (!requestReloadFlag or scanCountByReloaded is 1) and
       (!lastDisplay.bottom or lastDisplay.resNum is last)

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -1065,8 +1065,10 @@ app.viewThread._draw = ($view, {forceUpdate = false, jumpResNum = -1} = {}) ->
   $view.style.cursor = "auto"
   unless ok
     throw new Error("スレの表示に失敗しました")
-  await app.defer5()
-  $reloadButton.removeClass("disabled")
+  do ->
+    await app.defer5()
+    $reloadButton.removeClass("disabled")
+    return
   return thread
 
 app.viewThread._readStateManager = ($view) ->

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -21,6 +21,11 @@
   100% {transform: rotate(315deg);}
 }
 
+@keyframes fadeIn {
+  0% {opacity: 0;}
+  100% {opacity: 1;}
+}
+
 header, body {
   font-size: 15px;
 }
@@ -276,7 +281,7 @@ header {
     padding: 5px;
     background-color: rgba(black, 0.8);
     color: #eeeeee;
-    animation: fade_in 150ms ease-out;
+    animation: fadeIn 150ms ease-out;
   }
   .ng_count {
     display: block;

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -26,6 +26,7 @@ header, body {
 }
 
 .content {
+  contain: layout size;
   padding-bottom: 50px;
   &[data-res-search-hit-count="0"]::after {
     display: block;
@@ -39,6 +40,7 @@ header, body {
 }
 
 article {
+  contain: layout;
   padding: 0 5px 20px 5px;
   &.ng {
     display: none;
@@ -111,6 +113,7 @@ article {
 }
 
 header {
+  contain: content;
   display: inline-block;
   font-size: 14px;
   cursor: pointer;
@@ -256,6 +259,7 @@ header {
 }
 
 .popup {
+  contain: content;
   position: fixed;
   z-index: var(--z-index-popup);
   overflow: auto;
@@ -263,6 +267,7 @@ header {
   border: 3px solid #666;
   border-radius: 3px;
   > article {
+    contain: content;
     padding: 10px;
   }
   &.popup_linkinfo {
@@ -296,6 +301,7 @@ header {
 }
 
 .jump_panel {
+  contain: content;
   @include drop-shadow;
   $radius: 2px;
   position: absolute;
@@ -338,7 +344,12 @@ header {
   }
 }
 
+.popup_area {
+  contain: layout size;
+}
+
 .thread_footer {
+  contain: content;
   position: absolute;
   bottom: 0;
   left: 0;
@@ -369,6 +380,7 @@ header {
 }
 
 .next_thread_list {
+  contain: content;
   @include drop-shadow;
 
   background-color: hsla(0, 0%, 0%, 0.85);

--- a/src/write/submit_res.coffee
+++ b/src/write/submit_res.coffee
@@ -44,9 +44,11 @@ app.boot("/write/submit_res.html", ->
     mails = []
     for {input_name, input_mail} in data
       if names.length <= 5
-        names.push(input_name) unless names.includes(input_name)
+        unless input_name is "" or names.includes(input_name)
+          names.push(input_name)
       if mails.length <= 5
-        mails.push(input_mail) unless mails.includes(input_mail)
+        unless input_mail is "" or mails.includes(input_mail)
+          mails.push(input_mail)
       if names.length+mails.length >= 10
         break
     $names = $__("datalist")

--- a/src/write/write.scss
+++ b/src/write/write.scss
@@ -165,5 +165,8 @@ iframe {
     &[disabled] {
       background-color: #ddd;
     }
+    &:focus {
+      border-color: #36f;
+    }
   }
 }


### PR DESCRIPTION
Update: 検索モード切替時に検索結果を更新するように

Fix: 長大なスレでの負荷を軽減
 - Fix: CSSContainmentの設定
    - DOM追加時(ポップアップなど)の再描画範囲を抑制
 - Fix: 既読位置の取得時のループ回数が少なくなるように
    - レス数が多いスレの場合でかつ最後のレスなどを見ている場合、250msごとにレス数分のループが回っていた->直近に見たレスの周囲からスキャンするように

Fix: AA表示/解除でAAの縮小/解除が行われていなかったのを修正

Fix: 書込履歴への追加に時間がかかっていたのを修正

Fix: 書込の名前/メール履歴が5件ではなく4件しか表示されないことがあったのを修正

Fix: 背景が黒のときに書込画面でフォーカスの表示がなかったのを修正

Fix: 「URL指定で開く」の開くボタンがつぶれていたのを修正

Fix: レス内のリンク先情報ポップアップのアニメーションが動いていなかったのを修正

Fix: テーブルの幅をより適したものに

Fix: .search_hitが検索終了時に正常に取れていなかったのを修正

Fix: thread以外もCSSContainmentを設定

Fix: リファクタリング
 - `dom.style[kebab-case]` -> `dom.style.camelCase`
 - `dom.style.prop = ""` -> `dom.style.prop = null`
 - `while true` -> `loop`