### PR TITLE
Fix: ReplaceStr.txtのex2ですべての置き換えをしていなかったのを修正+α

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -31,7 +31,6 @@ pugCompiler = require "pug"
 args =
   outputPath: "./debug"
   manifestPath: "./src/manifest.json"
-  cssPath: "./src/**/*.scss"
   appTsPath: "./src/app.ts"
   backgroundCoffeePath: "./src/background.coffee"
   csaddlinkCoffeePath: "./src/cs_addlink.coffee"
@@ -40,8 +39,10 @@ args =
   uiCoffeePath: "./src/ui/*.coffee"
   uiTsPath: "./src/ui/*.ts"
   uiCssPath: "./src/ui/ui.scss"
+  uiCssWatchPath: ["./src/ui/*.scss", "./src/common.scss"]
   viewCoffeePath: "./src/view/*.coffee"
   viewCssPath: "./src/view/*.scss"
+  viewCssWatchPath: ["./src/view/*.scss", "./src/common.scss"]
   viewHtmlPath: "./src/view/*.pug"
   zombieCoffeePath: "./src/zombie.coffee"
   zombieHtmlPath: "./src/zombie.pug"
@@ -65,6 +66,7 @@ args =
         "./src/write/submit_thread.coffee"
       ]
   writeCssPath: ["./src/write/*.scss", "!./src/write/write.scss"]
+  writeCssWatchPath: ["./src/write/*.scss", "./src/common.scss"]
   writeHtmlPath: "./src/write/*.pug"
   webpSrcPath: "./src/image/svg"
   webpBinPath: "./debug/img"
@@ -439,7 +441,9 @@ gulp.task "watch", gulp.series("default", ->
   gulp.watch(args.writePath.cs.coffee, gulp.task("cs_write.js"))
   gulp.watch([args.writePath.submit_res.ts, args.writePath.submit_res.coffee], gulp.task("submit_res.js"))
   gulp.watch([args.writePath.submit_thread.ts, args.writePath.submit_thread.coffee], gulp.task("submit_thread.js"))
-  gulp.watch(args.cssPath, gulp.task("css"))
+  gulp.watch(args.uiCssWatchPath, gulp.task("ui.css"))
+  gulp.watch(args.viewCssWatchPath, gulp.task("viewcss"))
+  gulp.watch(args.writeCssWatchPath, gulp.task("writecss"))
   gulp.watch(args.viewHtmlPath, gulp.task("viewhtml"))
   gulp.watch(args.zombieHtmlPath, gulp.task("zombie.html"))
   gulp.watch(args.writeHtmlPath, gulp.task("writehtml"))

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       "dev": true
     },
     "ShortQuery.js": {
-      "version": "github:S--Minecraft/ShortQuery.js#f1b2a92502c2c938d6cdf16589543c73e009e6eb",
+      "version": "github:S--Minecraft/ShortQuery.js#6e809f8007e6a9efb677c0e32c69d5c543a38edd",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=4.5"
   },
   "devDependencies": {
-    "ShortQuery.js": "github:S--Minecraft/ShortQuery.js#1.0.3",
+    "ShortQuery.js": "github:S--Minecraft/ShortQuery.js#1.1.0",
     "coffeescript": "^2.3.1",
     "crx": "^3.2.1",
     "fs-extra": "^6.0.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -45,9 +45,21 @@ namespace app {
     });
   }
 
-  export function defer5 ():Promise<void> {
+  export function wait (ms: number): Promise<void> {
+    return new Promise( (resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+
+  export function wait5s (): Promise<void> {
     return new Promise( (resolve) => {
       setTimeout(resolve, 5 * 1000);
+    });
+  }
+
+  export function waitAF (): Promise<void> {
+    return new Promise( (resolve) => {
+      requestAnimationFrame(<any>resolve);
     });
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -380,18 +380,29 @@ namespace app {
     config = new Config();
   }
 
-  export const AMP_REG = /\&/g;
-  export const LT_REG = /</g;
-  export const GT_REG = />/g;
-  export const QUOT_REG = /"/g;
-  export const APOS_REG = /'/g;
+  export function replaceAll (str:string, before:string, after:string): string {
+    var i = str.indexOf(before);
+    if (i === -1) return str;
+    var result = str.slice(0, i) + after;
+    var j = str.indexOf(before, i+before.length);
+    while (j !== -1) {
+      result += str.slice(i+before.length, j) + after;
+      i = j;
+      j = str.indexOf(before, i+before.length);
+    }
+    return result + str.slice(i+before.length);
+  }
+
   export function escapeHtml (str:string):string {
-    return str
-      .replace(AMP_REG, "&amp;")
-      .replace(LT_REG, "&lt;")
-      .replace(GT_REG, "&gt;")
-      .replace(QUOT_REG, "&quot;")
-      .replace(APOS_REG, "&apos;");
+    return replaceAll(
+      replaceAll(
+        replaceAll(
+          replaceAll(
+            replaceAll(str, "&", "&amp;")
+          , "<", "&lt;")
+        , ">", "&gt;")
+      , '"', "&quot;")
+    , "'", "&apos;");
   }
 
   export function safeHref (url:string):string {

--- a/src/core/BBSMenu.coffee
+++ b/src/core/BBSMenu.coffee
@@ -82,11 +82,11 @@ class app.BBSMenu
       obj = await BBSMenu._updatingPromise
       obj.status = "success"
       if forceReload
-        BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: obj))
+        BBSMenu.target.emit(new CustomEvent("change", detail: obj))
     catch obj
       obj.status = "error"
       if forceReload
-        BBSMenu.target.dispatchEvent(new CustomEvent("change", detail: obj))
+        BBSMenu.target.emit(new CustomEvent("change", detail: obj))
     return obj
 
   ###*

--- a/src/core/Cache.coffee
+++ b/src/core/Cache.coffee
@@ -186,14 +186,16 @@ class app.Cache
       app.log("error", "Cache::put: データが不正です", @)
       throw new Error("キャッシュしようとしたデータが不正です")
 
+    data = if @data? then app.replaceAll(@data, "\u0000", "\u0020") else null
+
     try
       db = await Cache._dbOpen
       req = db
         .transaction("Cache", "readwrite")
         .objectStore("Cache")
-        .put(
+        .put({
           url: @key
-          data: @data?.replace(/\u0000/g, "\u0020") or null
+          data
           parsed: @parsed or null
           last_updated: @lastUpdated
           last_modified: @lastModified or null
@@ -201,7 +203,7 @@ class app.Cache
           res_length: @resLength or null
           dat_size: @datSize or null
           readcgi_ver: @readcgiVer or null
-        )
+        })
       await app.util.indexedDBRequestToPromise(req)
     catch e
       app.log("error", "Cache::put: トランザクション中断")

--- a/src/core/HTTP.ts
+++ b/src/core/HTTP.ts
@@ -79,11 +79,11 @@ namespace app.HTTP {
         });
 
         xhr.on("timeout", () => {
-          reject();
+          reject("timeout");
         });
 
         xhr.on("abort", () => {
-          reject();
+          reject("abort");
         });
 
         xhr.send();

--- a/src/core/ReplaceStrTxt.coffee
+++ b/src/core/ReplaceStrTxt.coffee
@@ -140,16 +140,25 @@ class app.ReplaceStrTxt
           flag = !flag
         continue unless flag
       if d.type is "ex2"
-        before = d.before
+        {place, before, after} = d
+        if place is "all"
+          res =
+            name: app.replaceAll(res.name, before, after)
+            mail: app.replaceAll(res.mail, before, after)
+            other: app.replaceAll(res.other, before, after)
+            message: app.replaceAll(res.message, before, after)
+        else
+          place = _PLACE_TABLE.get(place)
+          res[place] = app.replaceAll(res[place], before, after)
       else
-        before = d.beforeReg
-      if d.place is "all"
-        res =
-          name: res.name.replace(before, d.after)
-          mail: res.mail.replace(before, d.after)
-          other: res.other.replace(before, d.after)
-          message: res.message.replace(before, d.after)
-      else
-        place = _PLACE_TABLE.get(d.place)
-        res[place] = res[place].replace(before, d.after)
+        {place, beforeReg: before, after} = d
+        if place is "all"
+          res =
+            name: res.name.replace(before, after)
+            mail: res.mail.replace(before, after)
+            other: res.other.replace(before, after)
+            message: res.message.replace(before, after)
+        else
+          place = _PLACE_TABLE.get(place)
+          res[place] = res[place].replace(before, after)
     return res

--- a/src/core/ReplaceStrTxt.coffee
+++ b/src/core/ReplaceStrTxt.coffee
@@ -25,7 +25,7 @@ class app.ReplaceStrTxt
 
   #jsonには正規表現のオブジェクトが含めれないので
   #それを展開
-  _setupReg = () ->
+  _setupReg = ->
     for d from _replaceTable
       try
         d.beforeReg = switch d.type

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -8,7 +8,6 @@ app.util = {}
 class app.util.Anchor
   @reg =
     ANCHOR: /(?:&gt;|＞){1,2}[\d\uff10-\uff19]+(?:[\-\u30fc][\d\uff10-\uff19]+)?(?:\s*[,、]\s*[\d\uff10-\uff19]+(?:[\-\u30fc][\d\uff10-\uff19]+)?)*/g
-    _FW_DASH: /\u30fc/g
     _FW_NUMBER: /[\uff10-\uff19]/g
 
   @parseAnchor: (str) ->
@@ -16,7 +15,7 @@ class app.util.Anchor
       targetCount: 0
       segments: []
 
-    str = str.replace(Anchor.reg._FW_DASH, "-")
+    str = app.replaceAll(str, "\u30fc", "-")
     str = str.replace(Anchor.reg._FW_NUMBER, ($0) ->
       return String.fromCharCode($0.charCodeAt(0) - 65248)
     )
@@ -166,10 +165,9 @@ do ->
   kataHiraReg = ///[
     \u30a1-\u30f3 #ァ-ン
   ]///g
-  spaceReg = /[\u0020\u3000]/g
   # 検索用に全角/半角や大文字/小文字を揃える
   app.util.normalize = (str) ->
-    return str
+    str = str
       # 全角記号/英数を半角記号/英数に、半角カタカナを全角カタカナに変換
       .replace(
         wideSlimNormalizeReg
@@ -180,22 +178,25 @@ do ->
         kataHiraReg
         ($0) -> String.fromCharCode($0.charCodeAt(0) - 96)
       )
-      # 全角スペース/半角スペースを削除
-      .replace(spaceReg, "")
-      # 大文字を小文字に変換
-      .toLowerCase()
+    # 全角スペース/半角スペースを削除
+    str = app.replaceAll(
+      app.replaceAll(str, "\u0020", "")
+    , "\u3000", "")
+    # 大文字を小文字に変換
+    return str.toLowerCase()
 
   # striptags
   app.util.stripTags = (str) ->
     return str.replace(/(<([^>]+)>)/ig, "")
 
   titleReg = / ?(?:\[(?:無断)?転載禁止\]|(?:\(c\)|©|�|&copy;|&#169;)(?:2ch\.net|@?bbspink\.com)) ?/g
-  markReg = /<\/?mark>/g
   # タイトルから無断転載禁止などを取り除く
   app.util.removeNeedlessFromTitle = (title) ->
     title2 = title.replace(titleReg,"")
     title = if title2 is "" then title else title2
-    return title.replace(markReg, "")
+    return app.replaceAll(
+      app.replaceAll(title, "<mark>", "")
+    , "</mark>", "")
 
   app.util.promiseWithState = (promise) ->
     state = "pending"

--- a/src/cs_addlink.coffee
+++ b/src/cs_addlink.coffee
@@ -23,8 +23,7 @@ do ->
     if target.id is openButtonId
       a = document.createElement("a")
       a.href = url
-      event = new MouseEvent("click", {button, ctrlKey, shiftKey})
-      a.dispatchEvent(event)
+      a.emit(new MouseEvent("click", {button, ctrlKey, shiftKey}))
     else if target.id is closeButtonId
       @removeChild(target.parentElement)
     return

--- a/src/shortQuery.d.ts
+++ b/src/shortQuery.d.ts
@@ -56,8 +56,9 @@ interface DocumentFragment {
   last(): Element|null;
 }
 interface EventTarget {
-  on: EventTarget.addEventListener
-  off: EventTarget.removeEventListener
+  on: EventTarget.addEventListener;
+  off: EventTarget.removeEventListener;
+  emit: EventTarget.dispatchEvent;
 }
 interface Element {
   childClass: Element.getElementsByClassName;

--- a/src/ui/AANoOverflow.coffee
+++ b/src/ui/AANoOverflow.coffee
@@ -53,6 +53,7 @@ class UI.AANoOverflow
     return
 
   _setFontSizes: ->
+    await app.waitAF()
     $aaArticles = @$view.C("content")[0].C(_AA_CLASS_NAME)
     return unless $aaArticles.length > 0
 

--- a/src/ui/Accordion.ts
+++ b/src/ui/Accordion.ts
@@ -57,8 +57,8 @@ namespace UI {
     }
 
     close ($header: HTMLElement): void {
-      $header.removeClass("accordion_open")
-      UI.Animate.slideUp($header.next())
+      $header.removeClass("accordion_open");
+      UI.Animate.slideUp($header.next());
     }
   }
 }

--- a/src/ui/Animate.coffee
+++ b/src/ui/Animate.coffee
@@ -25,100 +25,75 @@ do ->
 
   _animatingMap = new WeakMap()
   _resetAnimatingMap = (ele) ->
-    _animatingMap.get(ele)?.dispatchEvent(_INVALIDED_EVENT)
+    _animatingMap.get(ele)?.emit(_INVALIDED_EVENT)
     return
 
   UI.Animate =
     fadeIn: (ele) ->
-      return new Promise( (resolve) ->
-        requestAnimationFrame( ->
-          _resetAnimatingMap(ele)
-          ele.removeClass("hidden")
+      await app.waitAF()
+      _resetAnimatingMap(ele)
+      ele.removeClass("hidden")
 
-          ani = ele.animate(_FADE_IN_FRAMES, _TIMING)
-          _animatingMap.set(ele, ani)
+      ani = ele.animate(_FADE_IN_FRAMES, _TIMING)
+      _animatingMap.set(ele, ani)
 
-          ani.on("finish", ->
-            _animatingMap.delete(ele)
-            return
-          , once: true)
-
-          resolve(ani)
-          return
-        )
+      ani.on("finish", ->
+        _animatingMap.delete(ele)
         return
-      )
+      , once: true)
+      return ani
     fadeOut: (ele) ->
-      return new Promise( (resolve) ->
-        _resetAnimatingMap(ele)
-        ani = ele.animate(_FADE_OUT_FRAMES, _TIMING)
-        _animatingMap.set(ele, ani)
+      _resetAnimatingMap(ele)
+      ani = ele.animate(_FADE_OUT_FRAMES, _TIMING)
+      _animatingMap.set(ele, ani)
 
-        invalided = false
-        ani.on("invalided", ->
-          invalided = true
-          return
-        , once: true)
-        ani.on("finish", ->
-          unless invalided
-            requestAnimationFrame( ->
-              ele.addClass("hidden")
-              _animatingMap.delete(ele)
-              return
-            )
-          return
-        , once: true)
-
-        resolve(ani)
+      invalided = false
+      ani.on("invalided", ->
+        invalided = true
         return
-      )
+      , once: true)
+      ani.on("finish", ->
+        unless invalided
+          await app.waitAF()
+          ele.addClass("hidden")
+          _animatingMap.delete(ele)
+        return
+      , once: true)
+      return Promise.resolve(ani)
     slideDown: (ele) ->
-      return new Promise(
-        requestAnimationFrame( ->
-          h = _getOriginHeight(ele)
+      await app.waitAF()
+      h = _getOriginHeight(ele)
 
-          _resetAnimatingMap(ele)
-          ele.removeClass("hidden")
+      _resetAnimatingMap(ele)
+      ele.removeClass("hidden")
 
-          ani = ele.animate({ height: ["0px", "#{h}px"] }, _TIMING)
-          _animatingMap.set(ele, ani)
+      ani = ele.animate({ height: ["0px", "#{h}px"] }, _TIMING)
+      _animatingMap.set(ele, ani)
 
-          ani.on("finish", ->
-            _animatingMap.delete(ele)
-            return
-          , once: true)
-
-          resolve(ani)
-          return
-        )
-      )
-    slideUp: (ele) ->
-      return new Promise( (resolve), ->
-        requestAnimationFrame( ->
-          h = ele.clientHeight
-
-          _resetAnimatingMap(ele)
-          ani = ele.animate({ height: ["#{h}px", "0px"] }, _TIMING)
-          _animatingMap.set(ele, ani)
-
-          invalided = false
-          ani.on("invalided", ->
-            invalided = true
-            return
-          , once: true)
-          ani.on("finish", ->
-            unless invalided
-              requestAnimationFrame( ->
-                ele.addClass("hidden")
-                _animatingMap.delete(ele)
-                return
-              )
-            return
-          , once: true)
-
-          resolve(ani)
-          return
-        )
+      ani.on("finish", ->
+        _animatingMap.delete(ele)
         return
-      )
+      , once: true)
+      return ani
+    slideUp: (ele) ->
+      await app.waitAF()
+      h = ele.clientHeight
+
+      _resetAnimatingMap(ele)
+      ani = ele.animate({ height: ["#{h}px", "0px"] }, _TIMING)
+      _animatingMap.set(ele, ani)
+
+      invalided = false
+      ani.on("invalided", ->
+        invalided = true
+        return
+      , once: true)
+      ani.on("finish", ->
+        unless invalided
+          await app.waitAF()
+          ele.addClass("hidden")
+          _animatingMap.delete(ele)
+        return
+      , once: true)
+      return ani
   return

--- a/src/ui/Animate.coffee
+++ b/src/ui/Animate.coffee
@@ -14,7 +14,6 @@ do ->
     e.style.cssText = """
       contain: content;
       height: auto;
-      width: #{ele.clientWidth}px;
       position: absolute;
       visibility: hidden;
       display: block;

--- a/src/ui/ContextMenu.coffee
+++ b/src/ui/ContextMenu.coffee
@@ -7,7 +7,7 @@ do ->
     if altParent
       altParent.removeClass("has_contextmenu")
       altParent.$(".popup.has_contextmenu").removeClass("has_contextmenu")
-      altParent.dispatchEvent(new Event("contextmenu_removed"))
+      altParent.emit(new Event("contextmenu_removed"))
       altParent = null
     return
 

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -251,9 +251,9 @@ namespace UI {
 
         this.$element.$(`li[data-tabid=\"${tabId}\"]`).dataset.tabsrc = param.url;
         $tmptab = this.$element.$(`iframe[data-tabid=\"${tabId}\"]`);
-        $tmptab.dispatchEvent(new Event("tab_beforeurlupdate", {"bubbles": true}));
+        $tmptab.emit(new Event("tab_beforeurlupdate", {"bubbles": true}));
         $tmptab.src = param.url;
-        $tmptab.dispatchEvent(new Event("tab_urlupdated", {"bubbles": true}));
+        $tmptab.emit(new Event("tab_urlupdated", {"bubbles": true}));
       }
 
       if (typeof param.title === "string") {
@@ -277,7 +277,7 @@ namespace UI {
           }
         }
 
-        $iframe.dispatchEvent(new Event("tab_selected", {"bubbles": true}));
+        $iframe.emit(new Event("tab_selected", {"bubbles": true}));
 
         // 遅延ロード指定のタブをロードする
         // 連続でlazy指定のタブがaddされた時のために非同期処理
@@ -340,7 +340,7 @@ namespace UI {
       $tmptab.remove();
 
       $tmptabcon = this.$element.$(`iframe[data-tabid=\"${tabId}\"]`);
-      $tmptabcon.dispatchEvent(new Event("tab_removed", {"bubbles": true}));
+      $tmptabcon.emit(new Event("tab_removed", {"bubbles": true}));
       $tmptabcon.remove();
 
       Tab.saveTabs()

--- a/src/ui/TableSorter.coffee
+++ b/src/ui/TableSorter.coffee
@@ -35,7 +35,7 @@ class UI.TableSorter
   ###
   update: ({sortIndex, sortAttribute, sortOrder} = {}) ->
     event = new Event("table_sort_before_update")
-    @table.dispatchEvent(event)
+    @table.emit(event)
     return if event.defaultPrevented
 
     if sortIndex? and sortOrder?
@@ -91,7 +91,7 @@ class UI.TableSorter
     else
       exparam.sort_attribute = sortAttribute
 
-    @table.dispatchEvent(new CustomEvent("table_sort_updated", { detail: exparam }))
+    @table.emit(new CustomEvent("table_sort_updated", { detail: exparam }))
     return
 
   ###*

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -227,7 +227,7 @@ class UI.ThreadContent
     loadImageByElement = (targetElement) =>
       for media in targetElement.$$("img[data-src], video[data-src]")
         loadFlag = true
-        media.dispatchEvent(new Event("immediateload", {"bubbles": true}))
+        media.emit(new Event("immediateload", {"bubbles": true}))
       return
 
     # 表示範囲内の要素をスキャンする
@@ -327,7 +327,7 @@ class UI.ThreadContent
           cancelAnimationFrame(@_scrollRequestID)
           rerunAndCancel = true if rerun
         do =>
-          @container.dispatchEvent(new Event("scrollstart"))
+          @container.emit(new Event("scrollstart"))
 
           to = target.offsetTop + offset
           movingHeight = to - @container.scrollTop
@@ -360,17 +360,17 @@ class UI.ThreadContent
               (change < 0 and @container.scrollTop < min)
             )
               @container.scrollTop = to
-              @container.dispatchEvent(new Event("scrollfinish"))
+              @container.emit(new Event("scrollfinish"))
               return
             # 正常時の処理
             if min <= @container.scrollTop <= max
               @container.scrollTop = to
-              @container.dispatchEvent(new Event("scrollfinish"))
+              @container.emit(new Event("scrollfinish"))
               return
             else
               @container.scrollTop += change
             if @container.scrollTop is before
-              @container.dispatchEvent(new Event("scrollfinish"))
+              @container.emit(new Event("scrollfinish"))
               return
             @_scrollRequestID = requestAnimationFrame(_scrollInterval)
             return
@@ -1212,7 +1212,7 @@ class UI.ThreadContent
     # 返信数の更新
     @updateRepCount()
     # 表示更新通知
-    @container.dispatchEvent(new Event("view_refreshed", {"bubbles": true}))
+    @container.emit(new Event("view_refreshed", {"bubbles": true}))
     return
 
   ###*

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -204,7 +204,7 @@ class UI.ThreadList
       $searchbox = option.searchbox
 
       $searchbox.on("compositionend", ->
-        @dispatchEvent(new Event("input"))
+        @emit(new Event("input"))
         return
       )
       $searchbox.on("input", ({isComposing}) ->
@@ -224,7 +224,7 @@ class UI.ThreadList
       $searchbox.on("keyup", ({which}) ->
         if which is 27 #Esc
           @value = ""
-          @dispatchEvent(new Event("input"))
+          @emit(new Event("input"))
         return
       )
 
@@ -279,7 +279,7 @@ class UI.ThreadList
                 $tr.remove()
               when target.hasClass("ignore_res_number")
                 $tr.setAttr("ignore-res-number", "on")
-                $tr.dispatchEvent(new Event("mousedown", {bubbles: true}))
+                $tr.emit(new Event("mousedown", {bubbles: true}))
               when target.hasClass("del_read_state")
                 app.ReadState.remove(threadURL)
 

--- a/src/ui/VirtualNotch.ts
+++ b/src/ui/VirtualNotch.ts
@@ -25,7 +25,7 @@ namespace UI {
         event = new MouseEvent("notchedmousewheel");
         event.wheelDelta = this.threshold * (this.wheelDelta > 0 ? 1 : -1);
         this.wheelDelta -= event.wheelDelta;
-        this.element.dispatchEvent(event);
+        this.element.emit(event);
       }
     }
   }

--- a/src/view/board.coffee
+++ b/src/view/board.coffee
@@ -83,10 +83,7 @@ app.boot("/view/board.html", ["board"], (Board) ->
 
     getReadStatePromise = do ->
       # request_update_read_stateを待つ
-      await new Promise( (resolve) ->
-        setTimeout(resolve, 150)
-        return
-      )
+      await app.wait(150)
       return await app.ReadState.getByBoard(url)
     getBoardPromise = do ->
       {status, message, data} = await Board.get(url)
@@ -153,13 +150,13 @@ app.boot("/view/board.html", ["board"], (Board) ->
     $view.removeClass("loading")
 
     if $table.hasClass("table_search")
-      $view.C("searchbox")[0].dispatchEvent(new Event("input"))
+      $view.C("searchbox")[0].emit(new Event("input"))
 
-    $view.dispatchEvent(new Event("view_loaded"))
+    $view.emit(new Event("view_loaded"))
 
     $button = $view.C("button_reload")[0]
     $button.addClass("disabled")
-    await app.defer5()
+    await app.wait5s()
     $button.removeClass("disabled")
     return
 

--- a/src/view/bookmark.coffee
+++ b/src/view/bookmark.coffee
@@ -89,7 +89,8 @@ app.boot("/view/bookmark.html", ["board"], (Board) ->
       if count.all is count.success + count.error
         #更新完了
         #ソート後にブックマークが更新されてしまう場合に備えて、少し待つ
-        setTimeout( ->
+        do ->
+          await app.wait(500)
           $view.C("table_sort_desc")[0]?.removeClass("table_sort_desc")
           $view.C("table_sort_asc")[0]?.removeClass("table_sort_asc")
           for tr in $view.$$("tr:not(.updated)")
@@ -99,11 +100,9 @@ app.boot("/view/bookmark.html", ["board"], (Board) ->
           if app.config.isOn("auto_bookmark_notify") and auto
             notify()
           $view.C("searchbox")[0].disabled = false
-          setTimeout(->
-            $reloadButton.removeClass("disabled")
-          , 1000 * 10)
+          await app.wait(10 * 1000)
+          $reloadButton.removeClass("disabled")
           return
-        , 500)
       # 同一サーバーへの最大接続数: 1
       for board from boardList
         server = app.URL.getDomain(board)
@@ -155,7 +154,7 @@ app.boot("/view/bookmark.html", ["board"], (Board) ->
     app.message.send("request_update_read_state")
     tableSorter.update()
 
-    $view.dispatchEvent(new Event("view_loaded"))
+    $view.emit(new Event("view_loaded"))
     return
 
   titleIndex = tableHeaders.indexOf("title")

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -108,7 +108,7 @@ class HistoryIO extends SettingIO
       try
         await @clearFunc()
         @$status.textContent = ":削除完了"
-        parent.$$.$("iframe[src=\"/view/#{@name}.html\"]")?.contentWindow.C("view")[0].dispatchEvent(new Event("request_reload"))
+        parent.$$.$("iframe[src=\"/view/#{@name}.html\"]")?.contentWindow.C("view")[0].emit(new Event("request_reload"))
       catch
         @$status.textContent = ":削除失敗"
 
@@ -130,7 +130,7 @@ class HistoryIO extends SettingIO
       try
         await @clearRangeFunc(parseInt($$.C("#{@name}_date_range")[0].value))
         @$status.textContent = ":範囲指定削除完了"
-        parent.$$.$("iframe[src=\"/view/#{@name}.html\"]")?.contentWindow.C("view")[0].dispatchEvent(new Event("request_reload"))
+        parent.$$.$("iframe[src=\"/view/#{@name}.html\"]")?.contentWindow.C("view")[0].emit(new Event("request_reload"))
       catch
         @$status.textContent = ":範囲指定削除失敗"
 
@@ -477,7 +477,7 @@ app.boot("/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
       $$.I(@name).dataset.value = @value if @checked
       return
     )
-    $dom.dispatchEvent(new Event("change"))
+    $dom.emit(new Event("change"))
 
   # 設定をインポート/エクスポート
   new SettingIO(
@@ -492,24 +492,24 @@ app.boot("/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
             switch $key.getAttr("type")
               when "text", "range", "number"
                 $key.value = value
-                $key.dispatchEvent(new Event("input"))
+                $key.emit(new Event("input"))
               when "checkbox"
                 $key.checked = (value is "on")
-                $key.dispatchEvent(new Event("change"))
+                $key.emit(new Event("change"))
               when "radio"
                 for dom in $view.$$("input.direct[name=\"#{key}\"]")
                   if dom.value is value
                     dom.checked = true
-                $key.dispatchEvent(new Event("change"))
+                $key.emit(new Event("change"))
           else
             $keyTextArea = $view.$("textarea[name=\"#{key}\"]")
             if $keyTextArea?
               $keyTextArea.value = value
-              $keyTextArea.dispatchEvent(new Event("input"))
+              $keyTextArea.emit(new Event("input"))
             $keySelect = $view.$("select[name=\"#{key}\"]")
             if $keySelect?
               $keySelect.value = value
-              $keySelect.dispatchEvent(new Event("change"))
+              $keySelect.emit(new Event("change"))
          #config_theme_idは「テーマなし」の場合があるので特例化
          else
            if value is "none"
@@ -517,7 +517,7 @@ app.boot("/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
              $themeNone.click() unless $themeNone.checked
            else
              $view.$("input[name=\"theme_id\"]").value = value
-             $view.$("input[name=\"theme_id\"]").dispatchEvent(new Event("change"))
+             $view.$("input[name=\"theme_id\"]").emit(new Event("change"))
       return
     exportFunc: ->
       content = app.config.getAll()
@@ -532,7 +532,7 @@ app.boot("/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
     importFunc: (file) ->
       datDom = $view.$("textarea[name=\"image_replace_dat\"]")
       datDom.value = file
-      datDom.dispatchEvent(new Event("input"))
+      datDom.emit(new Event("input"))
       return
   )
 
@@ -542,7 +542,7 @@ app.boot("/view/config.html", ["cache", "bbsmenu"], (Cache, BBSMenu) ->
     importFunc: (file) ->
       replacestrDom = $view.$("textarea[name=\"replace_str_txt\"]")
       replacestrDom.value = file
-      replacestrDom.dispatchEvent(new Event("input"))
+      replacestrDom.emit(new Event("input"))
       return
   )
 

--- a/src/view/history.coffee
+++ b/src/view/history.coffee
@@ -46,9 +46,9 @@ app.boot("/view/history.html", ->
     threadList.addItem(data)
     $view.removeClass("loading")
     return if add and data.length is 0
-    $view.dispatchEvent(new Event("view_loaded"))
+    $view.emit(new Event("view_loaded"))
     $view.C("button_reload")[0].addClass("disabled")
-    await app.defer5()
+    await app.wait5s()
     $view.C("button_reload")[0].removeClass("disabled")
     return
 

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -75,11 +75,9 @@ class app.view.Index extends app.view.View
       # shortQueryがまだ読み込まれていないことがあるので標準APIで
       for t in $target
         t.contentDocument.getElementsByClassName("view")[0].classList.add("focus_effect")
-      setTimeout( ->
-        for t in $target
-          t.contentDocument.getElementsByClassName("view")[0].classList.remove("focus_effect")
-        return
-      , 200)
+      await app.wait(200)
+      for t in $target
+        t.contentDocument.getElementsByClassName("view")[0].classList.remove("focus_effect")
       return
     )
 
@@ -835,17 +833,17 @@ app.main = ->
 
       #view_loadedの翻訳
       when "view_loaded"
-        $iframe.dispatchEvent(new Event("view_loaded"))
+        $iframe.emit(new Event("view_loaded"))
 
       #request_focusの翻訳
       when "request_focus"
-        $iframe.dispatchEvent(new CustomEvent("request_focus", detail: message, bubbles: true))
+        $iframe.emit(new CustomEvent("request_focus", detail: message, bubbles: true))
     return
   )
 
   #データ保存等の後片付けを行なってくれるzombie.html起動
   window.on("beforeunload", ->
-    window.dispatchEvent(new Event("beforezombie"))
+    window.emit(new Event("beforezombie"))
     if localStorage.zombie_read_state?
       open("/zombie.html", undefined, "left=1,top=1,width=250,height=50")
     return
@@ -855,7 +853,7 @@ app.main = ->
     target = target.closest("iframe")
     return unless target?
     target.contentWindow.___e = new Event("view_unload", bubbles: true)
-    target.contentWindow.dispatchEvent(target.contentWindow.___e)
+    target.contentWindow.emit(target.contentWindow.___e)
     return
   $view.on("tab_removed", onRemove)
   $view.on("tab_beforeurlupdate", onRemove)

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -265,7 +265,8 @@ class app.view.Index extends app.view.View
       @hideKeyboardHelp()
       return
     , once: true)
-    UI.Animate.fadeIn($help).on("finish", ->
+    ani = await UI.Animate.fadeIn($help)
+    ani.on("finish", ->
       $help.focus()
     )
     return
@@ -481,7 +482,8 @@ app.main = ->
     $div.on("click", func = ({target, currentTarget: cTarget}) ->
       return unless target.matches("a, div:last-child")
       $div.off("click", func)
-      UI.Animate.fadeOut(cTarget).on("finish", =>
+      ani = await UI.Animate.fadeOut(cTarget)
+      ani.on("finish", =>
         cTarget.remove()
         return
       )
@@ -825,7 +827,8 @@ app.main = ->
           app.DOMData.get($iframe.closest(".tab"), "tab").remove($iframe.dataset.tabid)
         #モーダルのviewが送ってきた場合
         else if $iframe.matches("#modal > iframe")
-          UI.Animate.fadeOut($iframe).on("finish", ->
+          ani = await UI.Animate.fadeOut($iframe)
+          ani.on("finish", ->
             $iframe.remove()
             return
           )

--- a/src/view/index.scss
+++ b/src/view/index.scss
@@ -7,6 +7,7 @@ html, body, #body {
   width: 100%;
   height: 100%;
   margin: 0;
+  overflow: hidden;
 }
 
 html {

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -209,23 +209,23 @@ class app.view.IframeView extends app.view.View
       when "focusUpFrame", "focusDownFrame", "focusLeftFrame", "focusRightFrame"
         app.message.send("requestFocusMove", {command, repeatCount})
       when "r"
-        @$element.dispatchEvent(new Event("request_reload"))
+        @$element.emit(new Event("request_reload"))
       when "q"
         @close()
       when "openCommandBox"
         @_openCommandBox()
       when "enter"
-        @$element.C("selected")[0]?.dispatchEvent(
+        @$element.C("selected")[0]?.emit(
           new Event("mousedown", bubbles: true)
         )
-        @$element.C("selected")[0]?.dispatchEvent(
+        @$element.C("selected")[0]?.emit(
           new Event("mouseup", bubbles: true)
         )
       when "shift+enter"
-        @$element.C("selected")[0]?.dispatchEvent(
+        @$element.C("selected")[0]?.emit(
           new MouseEvent("mousedown", shiftKey: true, bubbles: true)
         )
-        @$element.C("selected")[0]?.dispatchEvent(
+        @$element.C("selected")[0]?.emit(
           new MouseEvent("mouseup", shiftKey: true, bubbles: true)
         )
       when "help"
@@ -397,7 +397,7 @@ class app.view.PaneContentView extends app.view.IframeView
 
       # request_reload(postMessage) -> request_reload(event) 翻訳処理
       if message.type is "request_reload"
-        @$element.dispatchEvent(new CustomEvent(
+        @$element.emit(new CustomEvent(
           "request_reload"
           detail:
             force_update: message.force_update is true
@@ -413,7 +413,7 @@ class app.view.PaneContentView extends app.view.IframeView
 
       # tab_selected(postMessage) -> tab_selected(event) 翻訳処理
       else if message.type is "tab_selected"
-        @$element.dispatchEvent(new Event("tab_selected", bubbles: true))
+        @$element.emit(new Event("tab_selected", bubbles: true))
       return
     )
 
@@ -486,7 +486,7 @@ class app.view.TabContentView extends app.view.PaneContentView
     # View内リロードボタン
     @$element.C("button_reload")[0]?.on("click", ({currentTarget}) =>
       if not currentTarget.hasClass("disabled")
-        @$element.dispatchEvent(new Event("request_reload"))
+        @$element.emit(new Event("request_reload"))
       return
     )
     return
@@ -678,7 +678,7 @@ class app.view.TabContentView extends app.view.PaneContentView
         $button.removeClass("hidden")
         if @$element.hasClass("view_bookmark")
           return setInterval( =>
-            @$element.dispatchEvent(new CustomEvent("request_reload", detail: true))
+            @$element.emit(new CustomEvent("request_reload", detail: true))
             return
           , second)
         else
@@ -688,7 +688,7 @@ class app.view.TabContentView extends app.view.PaneContentView
               app.config.isOn("auto_load_all") or
               parent.$$.$(".tab_container > iframe[data-url=\"#{url}\"]").hasClass("tab_selected")
             )
-              @$element.dispatchEvent(new Event("request_reload"))
+              @$element.emit(new Event("request_reload"))
             return
           , second)
       else
@@ -740,7 +740,7 @@ class app.view.TabContentView extends app.view.PaneContentView
 
     $button.on("click", =>
       $button.toggleClass("regexp")
-      @$element.dispatchEvent(new Event("change_search_regexp"))
+      @$element.emit(new Event("change_search_regexp"))
       return
     )
     return

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -241,7 +241,7 @@ class app.view.IframeView extends app.view.View
       switch which
         # Enter
         when 13
-          @execCommand(target.value.replace(/[\s]/g, ""))
+          @execCommand(target.value.replace(/\s/g, ""))
           @_closeCommandBox()
         # Esc
         when 27

--- a/src/view/search.coffee
+++ b/src/view/search.coffee
@@ -71,7 +71,7 @@ app.boot("/view/search.html", ["thread_search"], (ThreadSearch) ->
 
     $view.C("more")[0].addClass("hidden")
     do ->
-      await app.defer5()
+      await app.wait5s()
       $buttonReload.removeClass("disabled")
       return
     return

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -1209,13 +1209,19 @@ app.viewThread._readStateManager = ($view) ->
   window.on("beforeunload", onBeforezombie)
 
   #スクロールされたら定期的にスキャンを実行する
-  scrollFlg = false
+  doneScroll = false
+  isScaning = false
   scrollWatcher = setInterval( ->
-    if scrollFlg
-      scrollFlg = false
+    return if not doneScroll or isScaning
+    isScaning = true
+    requestAnimationFrame( ->
       scan(true)
       if readStateUpdated
         app.message.send("read_state_updated", {board_url: boardUrl, read_state: readState})
+      isScaning = false
+      return
+    )
+    doneScroll = false
     return
   , 250)
 
@@ -1234,7 +1240,7 @@ app.viewThread._readStateManager = ($view) ->
   )
 
   $content.on("scroll", ->
-    scrollFlg = true
+    doneScroll = true
     return
   , passive: true)
   $view.on("request_reload", ->

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -151,7 +151,7 @@ app.boot("/view/thread.html", ->
 
       #スクロールされなかった場合も余所の処理を走らすためにscrollを発火
       unless onScroll
-        $content.dispatchEvent(new Event("scroll"))
+        $content.emit(new Event("scroll"))
 
       #二度目以降のread_state_attached時
       $view.on("read_state_attached", ({ detail: {jumpResNum, requestReloadFlag, loadCount} = {} }) ->
@@ -491,7 +491,7 @@ app.boot("/view/thread.html", ->
         paramResNum = app.URL.getResNumber(target.dataset.href)
         target.dataset.paramResNum = paramResNum if paramResNum
       await app.defer()
-      target.dispatchEvent(e)
+      target.emit(e)
     return
 
   $view.on("click", onLink)
@@ -692,7 +692,7 @@ app.boot("/view/thread.html", ->
       onclick: (info, tab) =>
         target.setAttr("toggle-param-res-num", "on")
         await app.defer()
-        target.dispatchEvent(new Event("mousedown", {"bubbles": true}))
+        target.emit(new Event("mousedown", {"bubbles": true}))
         return
     })
     return
@@ -732,7 +732,7 @@ app.boot("/view/thread.html", ->
     return unless app.config.isOn("dblclick_reload")
     return unless target.hasClass("message")
     return if target.tagName is "A" or target.hasClass("thumbnail")
-    $view.dispatchEvent(new Event("request_reload"))
+    $view.emit(new Event("request_reload"))
     return
   )
 
@@ -803,7 +803,7 @@ app.boot("/view/thread.html", ->
     $searchbox = $view.C("searchbox")[0]
 
     $searchbox.on("compositionend", ->
-      @dispatchEvent(new Event("input"))
+      @emit(new Event("input"))
       return
     )
     $searchbox.on("input", ({ isComposing, detail: {isEnter = false} = {} }) ->
@@ -821,7 +821,7 @@ app.boot("/view/thread.html", ->
           )
           return
 
-      $content.dispatchEvent(new Event("searchstart"))
+      $content.emit(new Event("searchstart"))
       if @value isnt ""
         if typeof searchStoredScrollTop isnt "number"
           searchStoredScrollTop = $content.scrollTop
@@ -846,7 +846,7 @@ app.boot("/view/thread.html", ->
         $view.C("hit_count")[0].textContent = "#{hitCount}hit"
 
         if scrollTop is $content.scrollTop
-          $content.dispatchEvent(new Event("scroll"))
+          $content.emit(new Event("scroll"))
       else
         $content.removeClass("searching")
         $content.removeAttr("data-res-search-hit-count")
@@ -858,7 +858,7 @@ app.boot("/view/thread.html", ->
           $content.scrollTop = searchStoredScrollTop
           searchStoredScrollTop = null
 
-      $content.dispatchEvent(new Event("searchfinish"))
+      $content.emit(new Event("searchfinish"))
       return
     )
 
@@ -866,19 +866,19 @@ app.boot("/view/thread.html", ->
       if $content.hasClass("search_regexp")
         if which is 13 or which is 27 # Enter|Esc
           @value = "" if which is 27
-          @dispatchEvent(new CustomEvent("input", detail: {isEnter: true}))
+          @emit(new CustomEvent("input", detail: {isEnter: true}))
         return
       if which is 27 #Esc
         if @value isnt ""
           @value = ""
-          @dispatchEvent(new Event("input"))
+          @emit(new Event("input"))
       return
     )
 
     # 検索モードの切り替え
     $view.on("change_search_regexp", ->
       $content.toggleClass("search_regexp")
-      $searchbox.dispatchEvent(new CustomEvent("input", detail: {isEnter: true}))
+      $searchbox.emit(new CustomEvent("input", detail: {isEnter: true}))
       return
     )
     return
@@ -1041,9 +1041,9 @@ app.viewThread._draw = ($view, {forceUpdate = false, jumpResNum = -1} = {}) ->
     app.DOMData.get($view, "lazyload").scan()
 
     if $view.C("content")[0].hasClass("searching")
-      $view.C("searchbox")[0].dispatchEvent(new Event("input"))
+      $view.C("searchbox")[0].emit(new Event("input"))
 
-    $view.dispatchEvent(new CustomEvent("view_loaded", detail: {jumpResNum, loadCount}))
+    $view.emit(new CustomEvent("view_loaded", detail: {jumpResNum, loadCount}))
     return thread
 
   thread = new app.Thread($view.dataset.url)
@@ -1068,7 +1068,7 @@ app.viewThread._draw = ($view, {forceUpdate = false, jumpResNum = -1} = {}) ->
   unless ok
     throw new Error("スレの表示に失敗しました")
   do ->
-    await app.defer5()
+    await app.wait5s()
     $reloadButton.removeClass("disabled")
     return
   return thread
@@ -1122,7 +1122,7 @@ app.viewThread._readStateManager = ($view) ->
       else
         attachedReadState.received = readState.received
 
-      $view.dispatchEvent(new CustomEvent("read_state_attached", detail: {jumpResNum, requestReloadFlag, loadCount}))
+      $view.emit(new CustomEvent("read_state_attached", detail: {jumpResNum, requestReloadFlag, loadCount}))
       if attachedReadState.read > 0 and attachedReadState.received > 0
         app.message.send("read_state_updated", {board_url: boardUrl, read_state: readState})
       return
@@ -1141,7 +1141,7 @@ app.viewThread._readStateManager = ($view) ->
       $content.C("received")[0]?.removeClass("received")
       $content.child()[attachedReadState.received - 1]?.addClass("received")
       tmpReadState.received = attachedReadState.received
-    $view.dispatchEvent(new CustomEvent("read_state_attached", detail: {jumpResNum, requestReloadFlag, loadCount}))
+    $view.emit(new CustomEvent("read_state_attached", detail: {jumpResNum, requestReloadFlag, loadCount}))
     if tmpReadState.read and tmpReadState.received
       app.message.send("read_state_updated", {board_url: boardUrl, read_state: tmpReadState})
     requestReloadFlag = false
@@ -1214,13 +1214,13 @@ app.viewThread._readStateManager = ($view) ->
   scrollWatcher = setInterval( ->
     return if not doneScroll or isScaning
     isScaning = true
-    requestAnimationFrame( ->
+    do ->
+      await app.waitAF()
       scan(true)
       if readStateUpdated
         app.message.send("read_state_updated", {board_url: boardUrl, read_state: readState})
       isScaning = false
       return
-    )
     doneScroll = false
     return
   , 250)

--- a/src/view/writehistory.coffee
+++ b/src/view/writehistory.coffee
@@ -41,9 +41,9 @@ app.boot("/view/writehistory.html", ->
     threadList.addItem(data)
     $view.removeClass("loading")
     return if add and data.length is 0
-    $view.dispatchEvent(new Event("view_loaded"))
+    $view.emit(new Event("view_loaded"))
     $view.C("button_reload")[0].addClass("disabled")
-    await app.defer5()
+    await app.wait5s()
     $view.C("button_reload")[0].removeClass("disabled")
     return
 

--- a/src/write/write.coffee
+++ b/src/write/write.coffee
@@ -149,15 +149,13 @@ do ->
             timer.wake()
           when "success"
             $view.C("notice")[0].textContent = "書き込み成功"
-            setTimeout( ->
-              onSuccess(key)
-              chrome.tabs.getCurrent( ({id}) ->
-                chrome.tabs.remove(id)
-                return
-              )
-              return
-            , 3000)
             timer.kill()
+            await app.wait(3000)
+            onSuccess(key)
+            chrome.tabs.getCurrent( ({id}) ->
+              chrome.tabs.remove(id)
+              return
+            )
           when "confirm"
             UI.Animate.fadeIn($view.C("iframe_container")[0])
             timer.kill()

--- a/src/write/write.coffee
+++ b/src/write/write.coffee
@@ -172,10 +172,13 @@ do ->
       $view.C("hide_iframe")[0].on("click", ->
         timer.kill()
         $iframeContainer = $view.C("iframe_container")[0]
-        UI.Animate.fadeOut($iframeContainer).on("finish", ->
-          $iframeContainer.T("iframe")[0].remove()
+        do ->
+          ani = await UI.Animate.fadeOut($iframeContainer)
+          ani.on("finish", ->
+            $iframeContainer.T("iframe")[0].remove()
+            return
+          )
           return
-        )
         for dom from $view.$$("input, textarea")
           dom.disabled = false unless dom.hasClass("mail") and app.config.isOn("sage_flag")
         $view.C("notice")[0].textContent = ""


### PR DESCRIPTION
Update: gulpでimport先のcssの変更も見るように

Update: ShortQuery.js 1.1.0

Fix: ReplaceStr.txtのex2ですべての置き換えをしていなかったのを修正

Fix: 板一覧のアコーディオンをダブルクリックすると開いた表示で中身が表示されないことがあるのを修正

Fix: 板一覧のアコーディオンの開く挙動が少し変だったのを修正

Fix: 既読処理タイミングの改善

Fix: AAの縮小処理の実行タイミングの改善

Fix: タブの並び替えの負荷を軽減

Fix: リファクタリング
 - replaceAll()を実装
 - dispatchEvent -> emit
 - setTimeout -> wait
 - defer5 -> wait5s
 - requestAnimationFrame -> waitAF