### PR TITLE
 Fix: スレッドでj,kでのスクロールショートカットが動作しないのを修正 close #464+α

### DIFF
--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -384,7 +384,7 @@ class UI.ThreadContent
   @param {Number} beforeRead 直近に読んでいたレスの番号
   @return {Number} 現在読んでいると推測されるレスの番号
   ###
-  getRead: (beforeRead) ->
+  getRead: (beforeRead = 1) ->
     containerBottom = @container.scrollTop + @container.clientHeight
     $read = @container.children[beforeRead - 1]
     readTop = $read.offsetTop

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -33,6 +33,7 @@ header, body {
 .content {
   contain: size;
   padding-bottom: 50px;
+  backface-visibility: hidden;
   &[data-res-search-hit-count="0"]::after {
     display: block;
     position: absolute;


### PR DESCRIPTION
Fix: スレッドでj,kでのスクロールショートカットが動作しないのを修正 close #464
Fix: 長いスレのスクロールが重いのを改善 