### PR TITLE
Fix: 非推奨/ブラウザ独自プロパティ/メソッドなどの除去

### DIFF
--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -119,21 +119,21 @@ export decodeCharReference = (str) ->
 
 #マウスクリックのイベントオブジェクトから、リンク先をどう開くべきかの情報を導く
 openMap = new Map([
-  #which(number), shift(bool), ctrl(bool)の文字列
-  ["1falsefalse", { newTab: false, newWindow: false, background: false }]
-  ["1truefalse",  { newTab: false, newWindow: true,  background: false }]
+  #button(number), shift(bool), ctrl(bool)の文字列
+  ["0falsefalse", { newTab: false, newWindow: false, background: false }]
+  ["0truefalse",  { newTab: false, newWindow: true,  background: false }]
+  ["0falsetrue",  { newTab: true,  newWindow: false, background: true  }]
+  ["0truetrue",   { newTab: true,  newWindow: false, background: false }]
+  ["1falsefalse", { newTab: true,  newWindow: false, background: true  }]
+  ["1truefalse",  { newTab: true,  newWindow: false, background: false }]
   ["1falsetrue",  { newTab: true,  newWindow: false, background: true  }]
   ["1truetrue",   { newTab: true,  newWindow: false, background: false }]
-  ["2falsefalse", { newTab: true,  newWindow: false, background: true  }]
-  ["2truefalse",  { newTab: true,  newWindow: false, background: false }]
-  ["2falsetrue",  { newTab: true,  newWindow: false, background: true  }]
-  ["2truetrue",   { newTab: true,  newWindow: false, background: false }]
 ])
-export getHowToOpen = ({type, which, shiftKey, ctrlKey, metaKey}) ->
+export getHowToOpen = ({type, button, shiftKey, ctrlKey, metaKey}) ->
   ctrlKey or= metaKey
   def = {newTab: false, newWindow: false, background: false}
   if type is "mousedown"
-    key = "" + which + shiftKey + ctrlKey
+    key = "" + button + shiftKey + ctrlKey
     return openMap.get(key) if openMap.has(key)
   return def
 

--- a/src/ui/ContextMenu.coffee
+++ b/src/ui/ContextMenu.coffee
@@ -16,8 +16,8 @@ eventFn = (e) ->
   return
 
 doc = document.documentElement
-doc.on("keydown", (e) ->
-  if e.which is 27
+doc.on("keydown", ({key}) ->
+  if key is "Escape"
     cleanup()
   return
 )

--- a/src/ui/SelectableAccordion.ts
+++ b/src/ui/SelectableAccordion.ts
@@ -38,7 +38,7 @@ export default class SelectableAccordion extends Accordion {
     }
 
     target.addClass("selected");
-    target.scrollIntoViewIfNeeded();
+    target.scrollIntoView({behavior: "instant", block: "center", inline: "center"});
   }
 
   clearSelect (): void {

--- a/src/ui/Sortable.ts
+++ b/src/ui/Sortable.ts
@@ -76,9 +76,9 @@ export default class Sortable {
     };
   }
 
-  onMousedown ({target, which}): void {
+  onMousedown ({target, button}): void {
     if (target === this.container) return;
-    if (which !== 1) return;
+    if (button !== 0) return;
     if (
       this.option.exclude &&
       target!.matches(this.option.exclude)

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -57,9 +57,9 @@ export default class Tab {
       }
       var target = e.target.closest("li")
       if (target === null) return;
-      if (e.which === 3) return;
+      if (e.button === 2) return;
 
-      if (e.which === 2 && !target.hasClass("tab_locked")) {
+      if (e.button === 1 && !target.hasClass("tab_locked")) {
         tab.remove(target.dataset.tabid!);
       }
       else {

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -478,7 +478,7 @@ export default class ThreadList
     return unless target
 
     target.addClass("selected")
-    target.scrollIntoViewIfNeeded()
+    target.scrollIntoView(behavior: "instant", block: "center", inline: "center")
     return
 
   ###*

--- a/src/ui/ThreadList.coffee
+++ b/src/ui/ThreadList.coffee
@@ -227,8 +227,8 @@ export default class ThreadList
             dom.textContent = ""
         return
       )
-      $searchbox.on("keyup", ({which}) ->
-        if which is 27 #Esc
+      $searchbox.on("keyup", ({key}) ->
+        if key is "Escape"
           @value = ""
           @emit(new Event("input"))
         return

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -243,14 +243,12 @@ class app.view.IframeView extends app.view.View
   ###
   _setupCommandBox: ->
     $input = $__("input").addClass("command", "hidden")
-    $input.on("keydown", ({which, target}) =>
-      switch which
-        # Enter
-        when 13
+    $input.on("keydown", ({key, target}) =>
+      switch key
+        when "Enter"
           @execCommand(target.value.replace(/\s/g, ""))
           @_closeCommandBox()
-        # Esc
-        when 27
+        when "Escape"
           @_closeCommandBox()
       return
     )
@@ -277,27 +275,42 @@ class app.view.IframeView extends app.view.View
     app.DOMData.get($command, "lastActiveElement")?.focus()
     return
 
+  _keyboardCommandMap: new Map([
+    ["Escape", "clearSelect"]
+    ["h", "left"]
+    ["H", "focusLeftFrame"]
+    ["l", "right"]
+    ["L", "focusRightFrame"]
+    ["k", "up"]
+    ["K", "focusUpFrame"]
+    ["j", "down"]
+    ["J", "focusDownFrame"]
+    ["R", "r"]
+    ["W", "q"]
+    ["?", "help"]
+  ])
+
   ###*
   @method _setupKeyboard
   @private
   ###
   _setupKeyboard: ->
     @$element.on("keydown", (e) =>
-      {target, which, shiftKey, ctrlKey, metaKey} = e
+      {target, key, shiftKey, ctrlKey, metaKey} = e
       # F5 or Ctrl+r or ⌘+r
-      if which is 116 or (ctrlKey and which is 82) or (metaKey and which is 82)
+      if key is "F5" or ( (ctrlKey or metaKey) and key is "r")
         e.preventDefault()
         command = "r"
       else if ctrlKey or metaKey
         return
 
       # Windows版ChromeでのBackSpace誤爆対策
-      if which is 8 and not (target.tagName in ["INPUT", "TEXTAREA"])
+      if key is "Backspace" and not (target.tagName in ["INPUT", "TEXTAREA"])
         e.preventDefault()
 
       # Esc (空白の入力欄に入力された場合)
       else if (
-        which is 27 and
+        key is "Escape" and
         target.tagName in ["INPUT", "TEXTAREA"] and
         target.value is "" and
         not target.hasClass("command")
@@ -306,73 +319,28 @@ class app.view.IframeView extends app.view.View
 
       # 入力欄内では発動しない系
       else if not (target.tagName in ["INPUT", "TEXTAREA"])
-        switch which
-          # Enter
-          when 13
-            if shiftKey
-              command = "shift+enter"
-            else
-              command = "enter"
-          # esc
-          when 27
-            command = "clearSelect"
-          # h
-          when 72
-            if shiftKey
-              command = "focusLeftFrame"
-            else
-              command = "left"
-          # l
-          when 76
-            if shiftKey
-              command = "focusRightFrame"
-            else
-              command = "right"
-          # k
-          when 75
-            if shiftKey
-              command = "focusUpFrame"
-            else
-              command = "up"
-          # j
-          when 74
-            if shiftKey
-              command = "focusDownFrame"
-            else
-              command = "down"
-          # r
-          when 82
-            # Shift+r
-            if shiftKey
-              command = "r"
-          # w
-          when 87
-            # Shift+w
-            if shiftKey
-              command = "q"
-          # :
-          when 186
-            e.preventDefault() # コマンド入力欄に:が入力されるのを防ぐため
-            command = "openCommandBox"
-          # /
-          when 191
-            # ?
-            if shiftKey
-              command = "help"
-            # /
-            else
-              e.preventDefault()
-              @$element.$(".searchbox, form.search > input[type=\"search\"]").focus()
+        if @_keyboardCommandMap.has(key)
+          command = @_keyboardCommandMap.get(key)
+        else if key is "Enter"
+          if shiftKey
+            command = "shift+enter"
           else
-            # 数値
-            if 48 <= which <= 57
-              @_numericInput += which - 48
+            command = "enter"
+        else if key is ":"
+          e.preventDefault() # コマンド入力欄に:が入力されるのを防ぐため
+          command = "openCommandBox"
+        else if key is "/"
+          e.preventDefault()
+          @$element.$(".searchbox, form.search > input[type=\"search\"]").focus()
+        else if /^\d$/.test(key)
+          # 数値
+          @_numericInput += key
 
       if command?
         @execCommand(command, Math.max(1, +@_numericInput))
 
       # 0-9かShift以外が押された場合は数値入力を終了
-      unless 48 <= which <= 57 or which is 16
+      unless /^\d$/.test(key) or key is "Shift"
         @_numericInput = ""
       return
     )

--- a/src/view/module.coffee
+++ b/src/view/module.coffee
@@ -93,7 +93,7 @@ class app.view.View
       target = e.target.closest(".open_in_rcrx")
       return unless target?
       e.preventDefault()
-      return if e.which is 3
+      return if e.button is 2
       url = target.dataset.href or target.href
       title = target.dataset.title or target.textContent
       writtenResNum = if target.getAttr("ignore-res-number") is "on" then null else target.dataset.writtenResNum
@@ -489,7 +489,7 @@ class app.view.TabContentView extends app.view.PaneContentView
 
     for dom in @$element.$$(".button_back, .button_forward")
       dom.on("mousedown", (e) ->
-        if e.which isnt 3
+        if e.button isnt 2
           {newTab, newWindow, background} = app.util.getHowToOpen(e)
           newTab or= newWindow
 

--- a/src/view/sidemenu.coffee
+++ b/src/view/sidemenu.coffee
@@ -24,8 +24,8 @@ app.boot("/view/sidemenu.html", ["BBSMenu"], (BBSMenu) ->
     return $li
 
   #スレタイ検索ボックス
-  $view.C("search")[0].on("keydown", ({which}) ->
-    if which is 27 #Esc
+  $view.C("search")[0].on("keydown", ({key}) ->
+    if key is "Escape"
       @q.value = ""
     return
   )

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -862,13 +862,13 @@ app.boot("/view/thread.html", ->
       return
     )
 
-    $searchbox.on("keydown", ({which}) ->
+    $searchbox.on("keydown", ({key}) ->
       if $content.hasClass("search_regexp")
-        if which is 13 or which is 27 # Enter|Esc
-          @value = "" if which is 27
+        if key in ["Enter", "Escape"]
+          @value = "" if key is "Escape"
           @emit(new CustomEvent("input", detail: {isEnter: true}))
         return
-      if which is 27 #Esc
+      if key is "Escape"
         if @value isnt ""
           @value = ""
           @emit(new Event("input"))


### PR DESCRIPTION
 - Fix: KeyboardEvent.which -> KeyboardEvent.key 
    - KeyboardEvent.whichが非推奨になっていたのと、ブラウザによって値が違うことで意図した動作が起こっていなかったため refs #474 (Firefoxでコマンド入力欄が開かないのを修正)
 - Fix: MouseEvent.which -> MouseEvent.button
    - whichは非標準のため標準化されているbuttonに書き換え
 - Fix: Firefoxで選択中の要素が画面に表示されるようスクロールされないのを修正
    - `Element.scrollIntoViewIfNeeded()`はChrome独自のため、標準化されている`Element.scrollIntoView()`に書き換え
    - それに伴い少し挙動が変更