### PR TITLE
Fix: スレ検索で検索結果を開けないことがある

### DIFF
--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -413,7 +413,7 @@ app.main = ->
     if res = /^search:(.+)$/.exec(url)
       param =
         query: res[1]
-        scheme: obj.scheme ? app.config.get("thread_search_last_mode")
+        scheme: obj.scheme ? app.config.get("thread_search_last_mode") ? "http"
       return
         src: "/view/search.html?#{app.URL.buildQuery(param)}"
         url: url


### PR DESCRIPTION
スレッド検索で、1度もhttp/https切り替えを実行していない場合、検索結果を開くことができなかったので修正しました。