### PR TITLE
Fix: 既読情報が終了時に保存されていなかったのを修正+α

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -247,7 +247,7 @@ class Config {
     ["no_history", "off"],
     ["no_writehistory", "off"],
     ["user_css", ""],
-    ["bbsmenu", "http://kita.jikkyo.org/cbm/cbm.cgi/20.p0.m0.jb.vs.op.sc.nb.bb/-all/bbsmenu.html"],
+    ["bbsmenu", "http://kita.jikkyo.org/cbm/cbm.cgi/5r.p5.m0.op.sc.99/-all/bbsmenu.html"],
     ["bbsmenu_update_interval", "7"],
     ["useragent", ""],
     ["format_2chnet", "html"],

--- a/src/background.coffee
+++ b/src/background.coffee
@@ -25,17 +25,16 @@ browser.browserAction.onClicked.addListener( (currentTab) ->
   return
 )
 
-# 終了通知の受信
 browser.runtime.onMessage.addListener( ({type}) ->
-  return unless type is "exit_rcrx"
-  # zombie.htmlが動いているかもしれないので10秒待機
-  setTimeout( ->
-    rcrx = await searchRcrx()
-    return if rcrx?
-    # 実行していなければメモリ解放のためにリロード
-    browser.runtime.reload()
-    return
-  , 1000 * 10)
+  switch type
+    # zombieの起動がrcrx_exitに間に合わなかった場合のためにもう一度送る
+    when "zombie_ping"
+      browser.runtime.sendMessage(type: "rcrx_exit")
+    when "zombie_done"
+      rcrx = await searchRcrx()
+      return if rcrx?
+      # 実行していなければメモリ解放のためにリロード
+      browser.runtime.reload()
   return
 )
 

--- a/src/view/board.coffee
+++ b/src/view/board.coffee
@@ -26,11 +26,22 @@ app.boot("/view/board.html", ["Board"], (Board) ->
     param.url = url
     windowX = app.config.get("write_window_x")
     windowY = app.config.get("write_window_y")
-    open(
-      "/write/submit_thread.html?#{app.URL.buildQuery(param)}"
-      undefined
-      "width=600,height=300,left=#{windowX},top=#{windowY}"
-    )
+    openUrl = "/write/submit_thread.html?#{app.URL.buildQuery(param)}"
+    if "&[BROWSER]" is "chrome"
+      parent.browser.windows.create(
+        type: "popup"
+        url: openUrl
+        width: 600
+        height: 300
+        left: parseInt(windowX)
+        top: parseInt(windowY)
+      )
+    else if "&[BROWSER]" is "firefox"
+      open(
+        openUrl
+        undefined
+        "width=600,height=300,left=#{windowX},top=#{windowY}"
+      )
     return
 
   $writeButton = $view.C("button_write")[0]

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -424,7 +424,7 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
 
     #ブックマークフォルダ表示
     do updateName = ->
-      [folder] = await browser.bookmarks.get(app.config.get("bookmark_id"))
+      [folder] = await parent.browser.bookmarks.get(app.config.get("bookmark_id"))
       $$.I("bookmark_source_name").textContent = folder.title
       return
     app.message.on("config_updated", ({key}) ->
@@ -566,7 +566,7 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
 
   # localstorageの使用状況
   do ->
-    if browser.storage.local.getBytesInUse?
+    if parent.browser.storage.local.getBytesInUse?
       # 無制限なのでindexeddbの最大と一致する
       {quota} = await navigator.storage.estimate()
       $view.C("localstorage_max")[0].textContent = formatBytes(quota)
@@ -574,7 +574,7 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
       $meter.max = quota
       $meter.high = quota*0.9
       $meter.low = quota*0.8
-      usage = await browser.storage.local.getBytesInUse()
+      usage = await parent.browser.storage.local.getBytesInUse()
       $view.C("localstorage_using")[0].textContent = formatBytes(usage)
       $meter.value = usage
     else

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -797,6 +797,7 @@ app.main = ->
     return unless type is "write_position"
     app.config.set("write_window_x", ""+x)
     app.config.set("write_window_y", ""+y)
+    return
   )
 
   # リクエスト・ヘッダーの監視

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -1191,10 +1191,7 @@ app.viewThread._readStateManager = ($view) ->
 
   #アンロード時は非同期系の処理をzombie.htmlに渡す
   #そのためにlocalStorageに更新するread_stateの情報を渡す
-  doneBeforezombie = false
   onBeforezombie = ->
-    return if doneBeforezombie
-    doneBeforezombie = true
     scan()
     if readStateUpdated
       if localStorage.zombie_read_state?
@@ -1206,7 +1203,6 @@ app.viewThread._readStateManager = ($view) ->
     return
 
   parent.window.on("beforezombie", onBeforezombie)
-  window.on("beforeunload", onBeforezombie)
 
   #スクロールされたら定期的にスキャンを実行する
   doneScroll = false
@@ -1257,7 +1253,6 @@ app.viewThread._readStateManager = ($view) ->
   window.on("view_unload", ->
     clearInterval(scrollWatcher)
     parent.window.off("beforezombie", onBeforezombie)
-    window.off("beforeunload", onBeforezombie)
     #ロード中に閉じられた場合、スキャンは行わない
     return if $view.hasClass("loading")
     scanAndSave()

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -56,11 +56,22 @@ app.boot("/view/thread.html", ->
     param.title = document.title
     windowX = app.config.get("write_window_x")
     windowY = app.config.get("write_window_y")
-    open(
-      "/write/submit_res.html?#{app.URL.buildQuery(param)}"
-      undefined
-      "width=600,height=300,left=#{windowX},top=#{windowY}"
-    )
+    openUrl = "/write/submit_res.html?#{app.URL.buildQuery(param)}"
+    if "&[BROWSER]" is "chrome"
+      parent.browser.windows.create(
+        type: "popup"
+        url: openUrl
+        width: 600
+        height: 300
+        left: parseInt(windowX)
+        top: parseInt(windowY)
+      )
+    else if "&[BROWSER]" is "firefox"
+      open(
+        openUrl
+        undefined
+        "width=600,height=300,left=#{windowX},top=#{windowY}"
+      )
     return
 
   popupHelper = (that, e, fn) ->

--- a/src/zombie.coffee
+++ b/src/zombie.coffee
@@ -1,4 +1,10 @@
 app.boot("/zombie.html", ->
+  close = ->
+    {id} = await browser.windows.getCurrent()
+    await browser.runtime.sendMessage(type: "zombie_done")
+    await browser.windows.remove(id)
+    return
+
   save = ->
     arrayOfReadState = JSON.parse(localStorage.zombie_read_state)
 
@@ -18,12 +24,20 @@ app.boot("/zombie.html", ->
     delete localStorage.zombie_read_state
     return
 
-  if localStorage.zombie_read_state?
-    $script = $__("script")
-    $script.on("load", save)
-    $script.src = "/app_core.js"
-    document.head.addLast($script)
-  else
-    close()
+  browser.runtime.sendMessage(type: "zombie_ping")
+
+  alreadyRun = false
+  browser.runtime.onMessage.addListener( ({type}) ->
+    return if alreadyRun or type isnt "rcrx_exit"
+    alreadyRun = true
+    if localStorage.zombie_read_state?
+      $script = $__("script")
+      $script.on("load", save)
+      $script.src = "/app_core.js"
+      document.head.addLast($script)
+    else
+      close()
+    return
+  )
   return
 )

--- a/src/zombie.pug
+++ b/src/zombie.pug
@@ -5,11 +5,11 @@ block vars
   - var title = "read.crx 2";
   - var html = {};
   - var htmlClasses = [""];
-  - var body = {};
+  - var body = {"style": "overflow: hidden"};
   - var needFavicon = true;
   - var needUI = false;
   - var needModule = false;
   - var needCss = false;
 
 block body
-  |read.crx 2 を終了しています
+  span(style={"font-size": "16px"}) read.crx 2 を終了しています


### PR DESCRIPTION
 - Fix: 既読情報が終了時に保存されていなかったのを修正
    - zombieが起動していなかった
    - ChromeとFirefoxで別の形式のウィンドウになっています(WebExtensions APIへの対応の関係)
    - できるだけ目障りにならないように
 - Update: Chromeで書込ウィンドウのURL欄を非表示に
    - [Firefoxのバグ](https://bugzilla.mozilla.org/show_bug.cgi?id=1396881)の関係でChromeだけに
 - Fix: 既定の板一覧URLを更新
 - Fix: 書き込み後にエラーが出ていたのを修正
    - `Failed to send onMessage rejected reply Error: Attempting to use a disconnected port object`
    - mozilla/webextension-polyfill #75
 - Fix: iframeからのWebExtensionAPIの呼び出しをindex.htmlからに統一
    - thead.htmlからはWebExtensionAPIの呼び出しが不可能だった(原因はよくわかりません)
    - config.htmlからは可能ではあったが、一応のため統一