### PR TITLE
Update: ホスト名付きサードレベルドメインの掲示板も読み込めるように+α

### DIFF
--- a/src/core/Board.coffee
+++ b/src/core/Board.coffee
@@ -229,14 +229,16 @@ export default class Board
       title = decodeCharReference(regRes[2])
       title = removeNeedlessFromTitle(title)
 
-      board.push(
+      resCount = +regRes[3]
+
+      board.push({
         url: baseUrl + regRes[1] + "/"
-        title: title
-        resCount: +regRes[3]
+        title
+        resCount
         createdAt: +regRes[1] * 1000
-        ng: isNGBoard(title, url)
+        ng: isNGBoard(title, url, resCount)
         isNet: if scFlg then !title.startsWith("★") else null
-      )
+      })
 
     if bbsType is "jbbs"
       board.pop()

--- a/src/core/Board.coffee
+++ b/src/core/Board.coffee
@@ -186,7 +186,7 @@ export default class Board
   @return {Object | null} xhrInfo
   ###
   @_getXhrInfo: (boardUrl) ->
-    tmp = ///^(https?)://((?:\w+\.)?(\w+\.\w+))/(\w+)(?:/(\d+)/|/?)$///.exec(boardUrl)
+    tmp = ///^(https?)://((?:\w+\.)*(\w+\.\w+))/(\w+)(?:/(\d+)/|/?)$///.exec(boardUrl)
     return null unless tmp
     return switch tmp[3]
       when "machi.to"
@@ -207,7 +207,7 @@ export default class Board
   @return {Array | null} board
   ###
   @parse: (url, text) ->
-    tmp = /^(https?):\/\/((?:\w+\.)?(\w+\.\w+))\/(\w+)(?:\/(\w+)|\/?)/.exec(url)
+    tmp = /^(https?):\/\/((?:\w+\.)*(\w+\.\w+))\/(\w+)(?:\/(\w+)|\/?)/.exec(url)
     scFlg = false
     switch tmp[3]
       when "machi.to"

--- a/src/core/NG.coffee
+++ b/src/core/NG.coffee
@@ -23,6 +23,7 @@ export TYPE =
   BODY: "Body"
   WORD: "Word"
   URL: "Url"
+  RES_COUNT: "ResCount"
   AUTO: "Auto"
   AUTO_CHAIN: "Chain"
   AUTO_CHAIN_ID: "ChainID"
@@ -159,6 +160,9 @@ parse = (string) ->
       when ngWord.startsWith("Url:")
         ngElement.type = TYPE.URL
         ngElement.word = ngWord.substr(4)
+      when ngWord.startsWith("ResCount:")
+        ngElement.type = TYPE.RES_COUNT
+        ngElement.word = parseInt(ngWord.substr(9))
       when ngWord.startsWith("Auto:")
         ngElement.type = TYPE.AUTO
         ngElement.word = ngWord.substr(5)
@@ -268,8 +272,8 @@ export add = (string) ->
 @param {String} subType
 @return {Object|null}
 ###
-export isNGBoard = (title, url, exceptionFlg = false, subType = null) ->
-  return checkNGThread({}, title, url, exceptionFlg, subType, true)
+export isNGBoard = (title, url, resCount, exceptionFlg = false, subType = null) ->
+  return checkNGThread({}, title, url, resCount, exceptionFlg, subType, true)
 
 ###*
 @method checkNGThread
@@ -281,7 +285,7 @@ export isNGBoard = (title, url, exceptionFlg = false, subType = null) ->
 @param {Boolean} isBoard
 @return {Object|null}
 ###
-export checkNGThread = (res, threadTitle, url, exceptionFlg = false, subType = null, isBoard = false) ->
+export checkNGThread = (res, threadTitle, url, resCount = null, exceptionFlg = false, subType = null, isBoard = false) ->
   tmpTitle = normalize(threadTitle)
   if isBoard
     tmpTxt1 = tmpTitle
@@ -311,7 +315,8 @@ export checkNGThread = (res, threadTitle, url, exceptionFlg = false, subType = n
       (n.type is TYPE.SLIP and res.slip?.includes(n.word)) or
       (n.type is TYPE.BODY and normalize(decodedMes).includes(n.word)) or
       (n.type is TYPE.WORD and tmpTxt2.includes(n.word)) or
-      (n.type is TYPE.URL and url.includes(n.word))
+      (n.type is TYPE.URL and url.includes(n.word)) or
+      (n.type is TYPE.RES_COUNT and n.word < resCount)
     )
       return n.type
     return null
@@ -321,7 +326,7 @@ export checkNGThread = (res, threadTitle, url, exceptionFlg = false, subType = n
     continue if n.type is TYPE.INVALID
     if isBoard
       # isNGBoard用の項目チェック
-      unless n.type in [TYPE.REG_EXP, TYPE.REG_EXP_TITLE, TYPE.TITLE, TYPE.WORD, TYPE.REG_EXP_URL, TYPE.URL]
+      unless n.type in [TYPE.REG_EXP, TYPE.REG_EXP_TITLE, TYPE.TITLE, TYPE.WORD, TYPE.REG_EXP_URL, TYPE.URL, TYPE.RES_COUNT]
         continue
     else
       # ignoreResNumber用レス番号のチェック
@@ -371,10 +376,10 @@ export isIgnoreResNumForAuto = (resNum, subType = "") ->
 @param {String} ngType
 @return {Boolean}
 ###
-export isIgnoreNgType = (res, threadTitle, url, ngType) ->
+export isIgnoreNgType = (res, threadTitle, url, resCount, ngType) ->
   return (
-    isNGBoard(threadTitle, url, true, ngType) or
-    checkNGThread(res, threadTitle, url, true, ngType)
+    isNGBoard(threadTitle, url, resCount, true, ngType) or
+    checkNGThread(res, threadTitle, url, resCount, true, ngType)
   )
 
 ###*

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -295,7 +295,7 @@ export default class Thread
   @return {null|Object}
   ###
   @_getXhrInfo = (url) ->
-    tmp = ///^(https?)://((?:\w+\.)?(\w+\.\w+))/(?:test|bbs)/read(?:_archive)?\.cgi/
+    tmp = ///^(https?)://((?:\w+\.)*(\w+\.\w+))/(?:test|bbs)/read(?:_archive)?\.cgi/
       (\w+)/(\d+)/(?:(\d+)/)?$///.exec(url)
     unless tmp then return null
     return switch tmp[3]

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -16,6 +16,7 @@ export default class Thread
     @res = null
     @message = null
     @tsld = getTsld(@url)
+    @expired = false
     return
 
   get: (forceUpdate, progress) ->
@@ -172,6 +173,7 @@ export default class Thread
         if thread
           @title = thread.title
           @res = thread.res
+          @expired = thread.expired?
         @message = ""
         resolve()
 
@@ -189,6 +191,10 @@ export default class Thread
               readcgiVer = parseInt(response.body.substr(readcgiPlace+38, 2))
             else
               readcgiVer = 5
+
+            # 2ch(html)のみ
+            if thread.expired
+              app.bookmark.updateExpired(@url, true)
 
           if deltaFlg
             if isHtml and !noChangeFlg
@@ -250,6 +256,7 @@ export default class Thread
             #移転検出出来なかった場合
             if response?.status is 203
               @message += "dat落ちしたスレッドです。"
+              thread.expired = true
             else
               @message += "スレッドの読み込みに失敗しました。"
           if hasCache and !thread
@@ -392,6 +399,9 @@ export default class Thread
           message: regRes[4]
           other: regRes[3]
         )
+
+    if text.includes("<div class=\"stoplight stopred stopdone\">")
+      thread.expired = true
 
     if thread.res.length > 0 and thread.res.length > numberOfBroken
       return thread

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -59,7 +59,7 @@ export function guessType (url:string):GuessResult {
   else if (/^https?:\/\/\w+\.(?:[25]ch|open2ch|bbspink)\.\w+\/(?:subback\/|test\/-\/)?\w+\/?$/.test(url)) {
     return {type: "board", bbsType: "2ch"};
   }
-  else if (/^https?:\/\/(\w+\.?)\w+\.\w+\/(?:subback\/|test\/-\/)?\w+\/?$/.test(url)) {
+  else if (/^https?:\/\/(?:\w+\.){2,}\w+\/(?:subback\/|test\/-\/)?\w+\/?$/.test(url)) {
     return {type: "board", bbsType: "2ch"};
   }
   else {

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -248,8 +248,8 @@ export default class Tab {
         history.current++;
       }
 
-      this.$element.$(`li[data-tabid=\"${tabId}\"]`).dataset.tabsrc = param.url;
-      $tmptab = this.$element.$(`iframe[data-tabid=\"${tabId}\"]`);
+      this.$element.$(`li[data-tabid="${tabId}"]`).dataset.tabsrc = param.url;
+      $tmptab = this.$element.$(`iframe[data-tabid="${tabId}"]`);
       $tmptab.emit(new Event("tab_beforeurlupdate", {"bubbles": true}));
       $tmptab.src = param.url;
       $tmptab.emit(new Event("tab_urlupdated", {"bubbles": true}));
@@ -259,7 +259,7 @@ export default class Tab {
       tmp = this.historyStore[tabId];
       tmp.stack[tmp.current].title = param.title;
 
-      $tmptab = this.$element.$(`li[data-tabid=\"${tabId}\"]`);
+      $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
       $tmptab.setAttr("title", param.title);
       $tmptab.T("span")[0].textContent = param.title;
     }
@@ -269,7 +269,7 @@ export default class Tab {
       for (var i = $selected.length-1; i >= 0; i--) {
         $selected[i].removeClass("tab_selected");
       }
-      for (var dom of this.$element.$$(`[data-tabid=\"${tabId}\"]`)) {
+      for (var dom of this.$element.$$(`[data-tabid="${tabId}"]`)) {
         dom.addClass("tab_selected");
         if (dom.hasClass("tab_content")) {
           $iframe = dom;
@@ -284,17 +284,17 @@ export default class Tab {
       var selectedTab, iframe: HTMLIFrameElement;
 
       if (selectedTab = this.getSelected()) {
-        iframe = this.$element.$(`iframe[data-tabid=\"${selectedTab.tabId}\"]`);
+        iframe = this.$element.$(`iframe[data-tabid="${selectedTab.tabId}"]`);
         if (iframe.getAttr("src") !== selectedTab.url) {
           iframe.src = selectedTab.url;
         }
       }
     }
     if (param.locked) {
-      $tmptab = this.$element.$(`li[data-tabid=\"${tabId}\"]`);
+      $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
       $tmptab.addClass("tab_locked");
     } else if (!(param.locked === void 0 || param.locked === null)) {
-      $tmptab = this.$element.$(`li[data-tabid=\"${tabId}\"].tab_locked`);
+      $tmptab = this.$element.$(`li[data-tabid="${tabId}"].tab_locked`);
       if ($tmptab !== null) {
         $tmptab.removeClass("tab_locked");
       }
@@ -310,7 +310,7 @@ export default class Tab {
 
     tab = this;
 
-    $tmptab = this.$element.$(`li[data-tabid=\"${tabId}\"]`);
+    $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
     tabsrc = $tmptab.dataset.tabsrc;
 
     for (tmp of tab.recentClosed) {
@@ -338,7 +338,7 @@ export default class Tab {
     }
     $tmptab.remove();
 
-    $tmptabcon = this.$element.$(`iframe[data-tabid=\"${tabId}\"]`);
+    $tmptabcon = this.$element.$(`iframe[data-tabid="${tabId}"]`);
     $tmptabcon.emit(new Event("tab_removed", {"bubbles": true}));
     $tmptabcon.remove();
 
@@ -363,7 +363,7 @@ export default class Tab {
   }
 
   isLocked (tabId: string): boolean {
-    var tab = this.$element.$(`li[data-tabid=\"${tabId}\"]`);
+    var tab = this.$element.$(`li[data-tabid="${tabId}"]`);
     return (tab !== null && tab.hasClass("tab_locked"));
   }
 }

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -59,6 +59,12 @@ export default class ThreadContent
     @oneId = null
 
     ###*
+    @property over1000ResNum
+    @type Number
+    ###
+    @over1000ResNum = null
+
+    ###*
     @property _lastScrollInfo
     @type Object
     @private
@@ -111,13 +117,6 @@ export default class ThreadContent
     @private
     ###
     @_scrollRequestID = 0
-
-    ###*
-    @property _over1000ResNum
-    @type Number
-    @private
-    ###
-    @_over1000ResNum = null
 
     ###*
     @property _rawResData
@@ -728,9 +727,9 @@ export default class ThreadContent
       if (
         bbsType is "2ch" and
         tmp.startsWith(_OVER1000_DATA) and
-        !@_over1000ResNum
+        !@over1000ResNum
       )
-        @_over1000ResNum = resNum
+        @over1000ResNum = resNum
 
       #文字色
       color = res.message.match(/<font color="(.*?)">/i)?[1]
@@ -1074,7 +1073,7 @@ export default class ThreadContent
   @private
   ###
   _getNgType: (objRes, bbsType) =>
-    return null if @_over1000ResNum? and objRes.num >= @_over1000ResNum
+    return null if @over1000ResNum? and objRes.num >= @over1000ResNum
     resCount = @container.child().length
 
     # 登録ワードのNG

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -982,6 +982,7 @@ export default class ThreadContent
   ###
   _chainNG: (res) =>
     resNum = +res.C("num")[0].textContent
+    resCount = @container.child().length
     return unless @repIndex.has(resNum)
     for r from @repIndex.get(resNum)
       continue if r <= resNum
@@ -989,7 +990,7 @@ export default class ThreadContent
       continue if getRes.hasClass("ng")
       rn = +getRes.C("num")[0].textContent
       continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.TYPE.AUTO_CHAIN)
-      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN)
+      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN)
       @setNG(getRes, app.NG.TYPE.AUTO_CHAIN)
       # NG連鎖IDの登録
       if app.config.isOn("chain_ng_id") and app.config.isOn("chain_ng_id_by_chain")
@@ -1010,12 +1011,13 @@ export default class ThreadContent
   @private
   ###
   _chainNgById: (id) =>
+    resCount = @container.child().length
     # 連鎖IDのNG
     for r in @container.$$("article[data-id=\"#{id}\"]")
       continue if r.hasClass("ng")
       rn = +r.C("num")[0].textContent
       continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.TYPE.AUTO_CHAIN_ID)
-      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_ID)
+      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN_ID)
       @setNG(r, app.NG.TYPE.AUTO_CHAIN_ID)
       # 連鎖NG
       @_chainNG(r) if app.config.isOn("chain_ng")
@@ -1027,12 +1029,13 @@ export default class ThreadContent
   @private
   ###
   _chainNgBySlip: (slip) =>
+    resCount = @container.child().length
     # 連鎖SLIPのNG
     for r in @container.$$("article[data-slip=\"#{slip}\"]")
       continue if r.hasClass("ng")
       rn = +r.C("num")[0].textContent
       continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.TYPE.AUTO_CHAIN_SLIP)
-      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_SLIP)
+      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN_SLIP)
       @setNG(r, app.NG.TYPE.AUTO_CHAIN_SLIP)
       # 連鎖NG
       @_chainNG(r) if app.config.isOn("chain_ng")
@@ -1072,11 +1075,12 @@ export default class ThreadContent
   ###
   _getNgType: (objRes, bbsType) =>
     return null if @_over1000ResNum? and objRes.num >= @_over1000ResNum
+    resCount = @container.child().length
 
     # 登録ワードのNG
     if (
       (ngObj = app.NG.checkNGThread(objRes, @_threadTitle, @url)) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, ngObj.type)
+      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, ngObj.type)
     )
       return ngObj
 
@@ -1091,7 +1095,7 @@ export default class ThreadContent
           (judgementIdType is "exists_once" and @idIndex.size isnt 0)
         ) and
         !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_NOTHING_ID) and
-        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_NOTHING_ID)
+        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_NOTHING_ID)
       )
         return {type: app.NG.TYPE.AUTO_NOTHING_ID}
       # slipなしをNG
@@ -1103,7 +1107,7 @@ export default class ThreadContent
           (judgementIdType is "exists_once" and @slipIndex.size isnt 0)
         ) and
         !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_NOTHING_SLIP) and
-        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_NOTHING_SLIP)
+        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_NOTHING_SLIP)
       )
         return {type: app.NG.TYPE.AUTO_NOTHING_SLIP}
 
@@ -1113,7 +1117,7 @@ export default class ThreadContent
       objRes.id? and
       @_ngIdForChain.has(objRes.id) and
       !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_CHAIN_ID) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_ID)
+      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN_ID)
     )
       return {type: app.NG.TYPE.AUTO_CHAIN_ID}
     # 連鎖SLIPのNG
@@ -1122,7 +1126,7 @@ export default class ThreadContent
       objRes.slip? and
       @_ngSlipForChain.has(objRes.slip) and
       !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_CHAIN_SLIP) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_SLIP)
+      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN_SLIP)
     )
       return {type: app.NG.TYPE.AUTO_CHAIN_SLIP}
 
@@ -1147,7 +1151,7 @@ export default class ThreadContent
       if (
         @_resMessageMap.get(resMessage).size >= +app.config.get("repeat_message_ng_count") and
         !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_REPEAT_MESSAGE) and
-        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_REPEAT_MESSAGE)
+        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_REPEAT_MESSAGE)
       )
         return {type: app.NG.TYPE.AUTO_REPEAT_MESSAGE}
 
@@ -1155,7 +1159,7 @@ export default class ThreadContent
     if (
       app.config.isOn("forward_link_ng") and
       !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_FORWARD_LINK) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_FORWARD_LINK)
+      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_FORWARD_LINK)
     )
       ngFlag = false
       resMessage = (

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -981,7 +981,6 @@ export default class ThreadContent
   ###
   _chainNG: (res) =>
     resNum = +res.C("num")[0].textContent
-    resCount = @container.child().length
     return unless @repIndex.has(resNum)
     for r from @repIndex.get(resNum)
       continue if r <= resNum
@@ -989,7 +988,7 @@ export default class ThreadContent
       continue if getRes.hasClass("ng")
       rn = +getRes.C("num")[0].textContent
       continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.TYPE.AUTO_CHAIN)
-      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN)
+      continue if app.NG.isThreadIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN)
       @setNG(getRes, app.NG.TYPE.AUTO_CHAIN)
       # NG連鎖IDの登録
       if app.config.isOn("chain_ng_id") and app.config.isOn("chain_ng_id_by_chain")
@@ -1010,13 +1009,12 @@ export default class ThreadContent
   @private
   ###
   _chainNgById: (id) =>
-    resCount = @container.child().length
     # 連鎖IDのNG
     for r in @container.$$("article[data-id=\"#{id}\"]")
       continue if r.hasClass("ng")
       rn = +r.C("num")[0].textContent
       continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.TYPE.AUTO_CHAIN_ID)
-      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN_ID)
+      continue if app.NG.isThreadIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_ID)
       @setNG(r, app.NG.TYPE.AUTO_CHAIN_ID)
       # 連鎖NG
       @_chainNG(r) if app.config.isOn("chain_ng")
@@ -1028,13 +1026,12 @@ export default class ThreadContent
   @private
   ###
   _chainNgBySlip: (slip) =>
-    resCount = @container.child().length
     # 連鎖SLIPのNG
     for r in @container.$$("article[data-slip=\"#{slip}\"]")
       continue if r.hasClass("ng")
       rn = +r.C("num")[0].textContent
       continue if app.NG.isIgnoreResNumForAuto(rn, app.NG.TYPE.AUTO_CHAIN_SLIP)
-      continue if app.NG.isIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN_SLIP)
+      continue if app.NG.isThreadIgnoreNgType(@_rawResData[rn], @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_SLIP)
       @setNG(r, app.NG.TYPE.AUTO_CHAIN_SLIP)
       # 連鎖NG
       @_chainNG(r) if app.config.isOn("chain_ng")
@@ -1074,12 +1071,11 @@ export default class ThreadContent
   ###
   _getNgType: (objRes, bbsType) =>
     return null if @over1000ResNum? and objRes.num >= @over1000ResNum
-    resCount = @container.child().length
 
     # 登録ワードのNG
     if (
-      (ngObj = app.NG.checkNGThread(objRes, @_threadTitle, @url)) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, ngObj.type)
+      (ngObj = app.NG.isNGThread(objRes, @_threadTitle, @url)) and
+      !app.NG.isThreadIgnoreNgType(objRes, @_threadTitle, @url, ngObj.type)
     )
       return ngObj
 
@@ -1094,7 +1090,7 @@ export default class ThreadContent
           (judgementIdType is "exists_once" and @idIndex.size isnt 0)
         ) and
         !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_NOTHING_ID) and
-        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_NOTHING_ID)
+        !app.NG.isThreadIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_NOTHING_ID)
       )
         return {type: app.NG.TYPE.AUTO_NOTHING_ID}
       # slipなしをNG
@@ -1106,7 +1102,7 @@ export default class ThreadContent
           (judgementIdType is "exists_once" and @slipIndex.size isnt 0)
         ) and
         !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_NOTHING_SLIP) and
-        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_NOTHING_SLIP)
+        !app.NG.isThreadIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_NOTHING_SLIP)
       )
         return {type: app.NG.TYPE.AUTO_NOTHING_SLIP}
 
@@ -1116,7 +1112,7 @@ export default class ThreadContent
       objRes.id? and
       @_ngIdForChain.has(objRes.id) and
       !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_CHAIN_ID) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN_ID)
+      !app.NG.isThreadIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_ID)
     )
       return {type: app.NG.TYPE.AUTO_CHAIN_ID}
     # 連鎖SLIPのNG
@@ -1125,7 +1121,7 @@ export default class ThreadContent
       objRes.slip? and
       @_ngSlipForChain.has(objRes.slip) and
       !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_CHAIN_SLIP) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_CHAIN_SLIP)
+      !app.NG.isThreadIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_CHAIN_SLIP)
     )
       return {type: app.NG.TYPE.AUTO_CHAIN_SLIP}
 
@@ -1150,7 +1146,7 @@ export default class ThreadContent
       if (
         @_resMessageMap.get(resMessage).size >= +app.config.get("repeat_message_ng_count") and
         !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_REPEAT_MESSAGE) and
-        !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_REPEAT_MESSAGE)
+        !app.NG.isThreadIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_REPEAT_MESSAGE)
       )
         return {type: app.NG.TYPE.AUTO_REPEAT_MESSAGE}
 
@@ -1158,7 +1154,7 @@ export default class ThreadContent
     if (
       app.config.isOn("forward_link_ng") and
       !app.NG.isIgnoreResNumForAuto(objRes.num, app.NG.TYPE.AUTO_FORWARD_LINK) and
-      !app.NG.isIgnoreNgType(objRes, @_threadTitle, @url, resCount, app.NG.TYPE.AUTO_FORWARD_LINK)
+      !app.NG.isThreadIgnoreNgType(objRes, @_threadTitle, @url, app.NG.TYPE.AUTO_FORWARD_LINK)
     )
       ngFlag = false
       resMessage = (

--- a/src/ui/_Tab.scss
+++ b/src/ui/_Tab.scss
@@ -82,6 +82,9 @@
   flex-grow: 1;
   overflow: hidden;
   position: relative;
+  &:-webkit-full-screen-ancestor {
+    contain: none;
+  }
 }
 
 .tab_content {

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -116,7 +116,7 @@ class HistoryIO extends SettingIO
       @afterChangedFunc()
       @$clearButton.removeClass("hidden")
       return
-    )
+    , once: true)
     return
   setupClearRangeButton: ->
     @$clearRangeButton.on("click", =>
@@ -138,7 +138,7 @@ class HistoryIO extends SettingIO
       @afterChangedFunc()
       @$clearRangeButton.removeClass("hidden")
       return
-    )
+    , once: true)
     return
   setupImportButton: ->
     @$importButton.on("click", =>

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -836,6 +836,11 @@ app.main = ->
         if $iframe.hasClass("tab_content")
           app.DOMData.get($iframe.closest(".tab"), "tab").update($iframe.dataset.tabid, {title})
 
+      # スレがover1000になったとき
+      when "became_over1000"
+        if $iframe.hasClass("tab_content")
+          $view.$("li[data-tabid=\"#{$iframe.dataset.tabid}\"]").addClass("over1000")
+
       #request_killmeの処理
       when "request_killme"
         #タブ内のviewが送ってきた場合

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -841,6 +841,11 @@ app.main = ->
         if $iframe.hasClass("tab_content")
           $view.$("li[data-tabid=\"#{$iframe.dataset.tabid}\"]").addClass("over1000")
 
+      # スレがdat落ちになったとき
+      when "became_expired"
+        if $iframe.hasClass("tab_content")
+          $view.$("li[data-tabid=\"#{$iframe.dataset.tabid}\"]").addClass("expired")
+
       #request_killmeの処理
       when "request_killme"
         #タブ内のviewが送ってきた場合

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -1051,7 +1051,11 @@ app.viewThread._draw = ($view, {forceUpdate = false, jumpResNum = -1} = {}) ->
     await threadContent.addItem(thread.res.slice($view.C("content")[0].child().length), thread.title)
     loadCount++
     app.DOMData.get($view, "lazyload").scan()
-    
+
+    if not $view.hasClass("expired") and thread.expired
+      $view.addClass("expired")
+      parent.postMessage({type: "became_expired"}, location.origin)
+
     if not $view.hasClass("over1000") and threadContent.over1000ResNum?
       $view.addClass("over1000")
       parent.postMessage({type: "became_over1000"}, location.origin)

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -1027,6 +1027,7 @@ app.boot("/view/thread.html", ->
 )
 
 app.viewThread._draw = ($view, {forceUpdate = false, jumpResNum = -1} = {}) ->
+  threadContent = app.DOMData.get($view, "threadContent")
   $view.addClass("loading")
   $view.style.cursor = "wait"
   $reloadButton = $view.C("button_reload")[0]
@@ -1047,9 +1048,13 @@ app.viewThread._draw = ($view, {forceUpdate = false, jumpResNum = -1} = {}) ->
 
     document.title = thread.title
 
-    await app.DOMData.get($view, "threadContent").addItem(thread.res.slice($view.C("content")[0].child().length), thread.title)
+    await threadContent.addItem(thread.res.slice($view.C("content")[0].child().length), thread.title)
     loadCount++
     app.DOMData.get($view, "lazyload").scan()
+    
+    if not $view.hasClass("over1000") and threadContent.over1000ResNum?
+      $view.addClass("over1000")
+      parent.postMessage({type: "became_over1000"}, location.origin)
 
     if $view.C("content")[0].hasClass("searching")
       $view.C("searchbox")[0].emit(new Event("input"))

--- a/src/view/thread.coffee
+++ b/src/view/thread.coffee
@@ -1055,10 +1055,12 @@ app.viewThread._draw = ($view, {forceUpdate = false, jumpResNum = -1} = {}) ->
     if not $view.hasClass("expired") and thread.expired
       $view.addClass("expired")
       parent.postMessage({type: "became_expired"}, location.origin)
+      $view.C("button_write")[0]?.remove()
 
     if not $view.hasClass("over1000") and threadContent.over1000ResNum?
       $view.addClass("over1000")
       parent.postMessage({type: "became_over1000"}, location.origin)
+      $view.C("button_write")[0]?.remove()
 
     if $view.C("content")[0].hasClass("searching")
       $view.C("searchbox")[0].emit(new Event("input"))

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -275,6 +275,15 @@ header {
   margin-top: 15px;
 }
 
+.expired article:last-child::after {
+  display: block;
+  content: "dat落ちしたスレッドです";
+  margin: 10px;
+  padding: 10px;
+  border: 1px solid;
+  border-radius: 5px;
+}
+
 .popup {
   contain: content;
   position: fixed;
@@ -607,7 +616,7 @@ header {
     }
   }
 
-  .rock54, .slipchange {
+  .rock54, .slipchange, &.expired .content > article:last-child::after {
     border-color: $thread-caution-border-color;
     background: $thread-caution-background-color;
   }

--- a/src/view/thread.scss
+++ b/src/view/thread.scss
@@ -269,6 +269,12 @@ header {
   display: none;
 }
 
+.rock54, .slipchange {
+  border: 1px solid;
+  border-radius: 3px;
+  margin-top: 15px;
+}
+
 .popup {
   contain: content;
   position: fixed;
@@ -602,10 +608,8 @@ header {
   }
 
   .rock54, .slipchange {
-    border: 1px solid $thread-caution-border-color;
-    border-radius: 3px;
+    border-color: $thread-caution-border-color;
     background: $thread-caution-background-color;
-    margin-top: 15px;
   }
 
   .content[data-res-search-hit-count="0"]::after {


### PR DESCRIPTION
 - Update: ホスト名付きサードレベルドメインの掲示板も読み込めるように
    - ex. http://yarufox.sakura.ne.jp/FOX
 - Update: レス数でスレをNGできるように
 - Update: 2chの1000レスを超えたタブに`.over1000`を付与するように
 - Update: 2ch(html)のdat落ちスレを判別できるように+タブへの`.expired`の付与
    - 2ch(html)だと正常にdat落ちスレも取得できるので、従来のdat落ちのエラーとは違った表示にしましたが、従来の位置である上部に青や緑などの別の色で表示するのとどちらがよいでしょう？
 - Fix: WindowsのChromeで動画をフルスクリーン化しても何も表示されないのを修正 close #470
 - Fix: データの削除を連打できたのを修正
 - Fix: リファクタリング