### PR TITLE
 Fix: 最終既読位置がレスの頭に一致している場合に位置が正しく記録されていない

### DIFF
--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -444,13 +444,13 @@ export default class ThreadContent
       loop
         if $next?
           nextTop = $next.offsetTop
-          if nextTop < containerTop < nextTop + $next.offsetHeight
+          if nextTop <= containerTop < nextTop + $next.offsetHeight
             $read = $next
             break
           $next = $next.next()
         if $prev?
           prevTop = $prev.offsetTop
-          if prevTop < containerTop < prevTop + $prev.offsetHeight
+          if prevTop <= containerTop < prevTop + $prev.offsetHeight
             $read = $prev
             break
           $prev = $prev.prev()


### PR DESCRIPTION
- [876999f](https://github.com/readcrx-2/read.crx-2/commit/876999f187a71569a86919ae9d7b21bbae942477)が間違いだったので、一部修正して復活させました。
- 最終既読位置が正しく記録されない場合があったので修正しました。