### PR TITLE
Fix: 検索結果/書込履歴のカラム省略がうまくいっていないのを修正 close #492+α

### DIFF
--- a/src/_common.scss
+++ b/src/_common.scss
@@ -72,6 +72,15 @@ $z-indexes:(
     }
   }
 
+  html {
+    scrollbar-face-color: #dddddd;
+    scrollbar-track-color: #999999;
+  }
+
+  html, .container, .content {
+    scrollbar-width: thin;
+  }
+
   .hidden {
     display: none;
   }

--- a/src/view/search.scss
+++ b/src/view/search.scss
@@ -14,7 +14,7 @@
 
 @media (max-width: 600px) {
   col, th {
-    :not(.bookmark):not(.title) {
+    &:not(.bookmark):not(.title) {
       width: 0;
     }
   }

--- a/src/view/search.scss
+++ b/src/view/search.scss
@@ -4,7 +4,7 @@
 @include tab-content;
 @include content-table;
 
-@media (max-width: 750px) and (min-width: 501px) {
+@media (max-width: 750px) and (min-width: 601px) {
   col, th {
     &.created_date {
       width: 0;

--- a/src/view/writehistory.scss
+++ b/src/view/writehistory.scss
@@ -4,10 +4,18 @@
 @include tab-content;
 @include content-table;
 
-@media (max-width: 500px) {
+@media (max-width: 750px) {
   col, th {
     &.written_date {
       width: 0;
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  col, th {
+    &.mail {
+      width: 4em;
     }
   }
 }

--- a/src/view/writehistory.scss
+++ b/src/view/writehistory.scss
@@ -6,7 +6,7 @@
 
 @media (max-width: 500px) {
   col, th {
-    .written_date {
+    &.written_date {
       width: 0;
     }
   }


### PR DESCRIPTION
 - Fix: 検索結果/書込履歴のカラム省略がうまくいっていないのを修正 close #492

 - Fix: 書込履歴のカラム省略を変更

 - Update: Firefoxでのスクロールバーの幅と色を変更
    - 色の変更を適用するにはFirefox62(現在の最新版)以降で`about:config`の`layout.css.scrollbar-colors.enabled`を`enabled`にする必要あり
    - 幅の変更を適用するにはFirefox63(現在のベータ版、10/23に正式版リリース予定)以降で`about:config`の`layout.css.scrollbar-width.enabled`を`enabled`にする必要あり

![scrollbar](https://user-images.githubusercontent.com/7892988/45869780-4691cc80-bdc4-11e8-96ca-ba74bf1a9bc3.png)

---

メモ
 - Chromeで有効になっている`CSS Containment`をFirefoxで利用するためには、`about:config`の`layout.css.contain.enabled`を`enabled`にする必要あり