### PR TITLE
Fix: Firefoxで設定や履歴のエクスポートができなかったのを修正

### DIFF
--- a/src/_common.scss
+++ b/src/_common.scss
@@ -73,8 +73,8 @@ $z-indexes:(
   }
 
   html {
-    scrollbar-face-color: #dddddd;
-    scrollbar-track-color: #999999;
+    scrollbar-face-color: #999999;
+    scrollbar-track-color: #bbbbbb;
   }
 
   html, .container, .content {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
   "description" : "2chブラウザ",
   "manifest_version": 2,
   "minimum_chrome_version" : "61",
-  "content_security_policy": "default-src 'self'; img-src 'self' http: https: data:; style-src 'self' 'unsafe-inline'; connect-src 'self' http: https:; frame-src 'self' http: https:; font-src data:; media-src 'self' http: https:",
+  "content_security_policy": "default-src 'self'; img-src 'self' http: https: data:; style-src 'self' 'unsafe-inline'; connect-src 'self' http: https:; frame-src 'self' http: https: blob:; font-src data:; media-src 'self' http: https:",
   "incognito" : "split",
   "options_ui" : {
     "page": "view/index.html?q=config",

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -54,12 +54,13 @@ class SettingIO
     return
   setupExportButton: ->
     @$exportButton.on("click", =>
-      blob = new Blob([@exportFunc()],{type:"text/plain"})
-      $a = $__("a")
+      blob = new Blob([@exportFunc()], type: "text/plain")
+      $a = $__("a").addClass("hidden")
       $a.href = URL.createObjectURL(blob)
-      $a.setAttr("target", "_blank")
       $a.setAttr("download", "read.crx-2_#{@name}.json")
+      @$exportButton.addAfter($a)
       $a.click()
+      $a.remove()
       return
     )
     return
@@ -167,11 +168,12 @@ class HistoryIO extends SettingIO
       data = await @exportFunc()
       exportText = JSON.stringify(data)
       blob = new Blob([exportText], type: "text/plain")
-      $a = $__("a")
+      $a = $__("a").addClass("hidden")
       $a.href = URL.createObjectURL(blob)
-      $a.setAttr("target", "_blank")
       $a.setAttr("download", "read.crx-2_#{@name}.json")
+      @$exportButton.addAfter($a)
       $a.click()
+      $a.remove()
       return
     )
     return


### PR DESCRIPTION
 - Fix: Firefoxで設定や履歴のエクスポートができなかったのを修正
 - Fix: Firefoxのスクロールバーの色が入れ替わっていたのを修正
    - +Firefoxではborderが設定できないので境界がわかるように背景を少し濃く