### PR TITLE
Fix: リファクタリング

### DIFF
--- a/src/core/Bookmark.ts
+++ b/src/core/Bookmark.ts
@@ -102,8 +102,7 @@ export class EntryList {
             this.update(b);
           }
         }
-      }
-      else {
+      } else {
         this.add(b);
       }
     }
@@ -141,25 +140,17 @@ export class EntryList {
   }
 
   getAll ():Entry[] {
-    var res:Entry[] = Array.from(this.cache.values());
-
-    return app.deepCopy(res);
+    return Array.from(this.cache.values());
   }
 
   getAllThreads ():Entry[] {
     var res:Entry[] = Array.from(this.cache.values());
-
-    res = res.filter( ({type}) => type === "thread");
-
-    return app.deepCopy(res);
+    return res.filter( ({type}) => type === "thread");
   }
 
   getAllBoards ():Entry[] {
     var res:Entry[] = Array.from(this.cache.values());
-
-    res = res.filter( ({type}) => type === "board");
-
-    return app.deepCopy(res);
+    return res.filter( ({type}) => type === "board");
   }
 
   getThreadsByBoardURL (url:string):Entry[] {
@@ -173,7 +164,7 @@ export class EntryList {
       }
     }
 
-    return app.deepCopy(res);
+    return res;
   }
 }
 
@@ -201,8 +192,7 @@ export class SyncableEntryList extends EntryList{
         entry: app.deepCopy(entry)
       });
       return true;
-    }
-    else {
+    } else {
       return false;
     }
   }
@@ -249,8 +239,7 @@ export class SyncableEntryList extends EntryList{
         });
       }
       return true;
-    }
-    else {
+    } else {
       return false;
     }
   }
@@ -264,8 +253,7 @@ export class SyncableEntryList extends EntryList{
         entry: entry
       });
       return true;
-    }
-    else {
+    } else {
       return false;
     }
   }

--- a/src/core/BookmarkCompatibilityLayer.ts
+++ b/src/core/BookmarkCompatibilityLayer.ts
@@ -58,79 +58,60 @@ export default class BookmarkCompatibilityLayer {
     return this.cbel.getAll();
   }
 
-  add (url:string, title:string, resCount?:number) {
-    return new Promise( async (resolve, reject) => {
-      var entry = BrowserBookmarkEntryList.URLToEntry(url)!;
+  async add (url:string, title:string, resCount?:number): Promise<boolean> {
+    var entry = BrowserBookmarkEntryList.URLToEntry(url)!;
 
-      entry.title = title;
+    entry.title = title;
 
-      var readState = await getReadState(entry.url)
-      if (readState) {
-        entry.readState = readState;
-      }
+    var readState = await getReadState(entry.url)
+    if (readState) {
+      entry.readState = readState;
+    }
 
-      if (
-        typeof resCount === "number" &&
-        (!entry.resCount || entry.resCount < resCount)
-      ) {
-        entry.resCount = resCount;
-      } else if (entry.readState) {
-        entry.resCount = entry.readState.received;
-      }
+    if (
+      typeof resCount === "number" &&
+      (!entry.resCount || entry.resCount < resCount)
+    ) {
+      entry.resCount = resCount;
+    } else if (entry.readState) {
+      entry.resCount = entry.readState.received;
+    }
 
-      this.cbel.add(entry, undefined, (res) => {
-        res ? resolve() : reject();
-      });
-    });
+    return this.cbel.add(entry);
   }
 
-  remove (url:string) {
-    return new Promise( (resolve, reject) => {
-      this.cbel.remove(url, undefined, (res) => {
-        res ? resolve() : reject();
-      });
-    });
+  async remove (url:string):Promise<boolean> {
+    return this.cbel.remove(url);
   }
 
-  updateReadState (readState) {
+  async updateReadState (readState):Promise<boolean> {
     // TODO
-    return new Promise( (resolve, reject) => {
-      var entry = this.cbel.get(readState.url);
+    var entry = this.cbel.get(readState.url);
 
-      if (entry) {
-        entry.readState = readState;
-        this.cbel.update(entry, undefined, (res) => {
-          res ? resolve() : reject();
-        });
-      } else {
-        resolve();
-      }
-    });
+    if (entry) {
+      entry.readState = readState;
+      return this.cbel.update(entry);
+    }
+    return true;
   }
 
-  updateResCount (url:string, resCount:number) {
-    return new Promise( (resolve, reject) => {
-      var entry = this.cbel.get(url);
+  async updateResCount (url:string, resCount:number):Promise<boolean> {
+    var entry = this.cbel.get(url);
 
-      if (entry && (!entry.resCount || entry.resCount < resCount)) {
-        entry.resCount = resCount;
-        this.cbel.update(entry, undefined, (res) => {
-          res ? resolve() : reject();
-        });
-      }
-    });
+    if (entry && (!entry.resCount || entry.resCount < resCount)) {
+      entry.resCount = resCount;
+      return this.cbel.update(entry);
+    }
+    return true;
   }
 
-  updateExpired (url:string, expired:boolean) {
-    return new Promise( (resolve, reject) => {
-      var entry = this.cbel.get(url);
+  async updateExpired (url:string, expired:boolean):Promise<boolean> {
+    var entry = this.cbel.get(url);
 
-      if (entry) {
-        entry.expired = expired;
-        this.cbel.update(entry, undefined, (res) => {
-          res ? resolve() : reject();
-        });
-      }
-    });
+    if (entry) {
+      entry.expired = expired;
+      return this.cbel.update(entry);
+    }
+    return true;
   }
 }

--- a/src/core/DOMData.coffee
+++ b/src/core/DOMData.coffee
@@ -5,9 +5,8 @@
 _list = new WeakMap()
 
 export set = (dom, prop, val) ->
-  obj = if _list.has(dom) then _list.get(dom) else {}
-  obj[prop] = val
-  _list.set(dom, obj)
+  _list.set(dom, {}) unless _list.has(dom)
+  _list.get(dom)[prop] = val
   return
 export get = (dom, prop) ->
   if _list.has(dom)

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -522,9 +522,9 @@ app.main = ->
   # ウィンドウサイズ関連処理
   adjustWindowSize = new app.Callbacks()
   do ->
-    resizeTo = (width, height, callback) ->
+    resizeTo = (width, height) ->
       win = await browser.windows.getCurrent()
-      browser.windows.update(win.id, {width, height}, callback)
+      await browser.windows.update(win.id, {width, height})
       return
 
     saveWindowSize = ->
@@ -555,16 +555,12 @@ app.main = ->
     do ->
       win = await browser.windows.getCurrent(populate: true)
       if win.tabs.length is 1 and win.width < 300 or win.height < 300
-        resizeTo(
+        await resizeTo(
           +app.config.get("window_width")
           +app.config.get("window_height")
-          ->
-            await app.defer()
-            adjustWindowSize.call()
-            return
         )
-      else
-        adjustWindowSize.call()
+        await app.defer()
+      adjustWindowSize.call()
       return
 
     adjustWindowSize.add(startAutoSave)

--- a/src/zombie.coffee
+++ b/src/zombie.coffee
@@ -21,7 +21,7 @@ app.boot("/zombie.html", ->
       await app.bookmark.promiseFirstScan
 
       rsarray = (app.ReadState.set(rs).catch(->return) for rs in arrayOfReadState)
-      bkarray = (app.bookmark.updateReadState(rs).catch(->return) for rs in arrayOfReadState)
+      bkarray = (app.bookmark.updateReadState(rs) for rs in arrayOfReadState)
       await Promise.all(rsarray.concat(bkarray))
 
     close()


### PR DESCRIPTION
Fix: リファクタリング
 - `}`と`else`の間の改行の除去
 - Immutableなメソッドの後に`app.deepCopy`していたところを除去
 - callback形式でWebExtensionAPIを呼び出していた箇所をPromiseに書き換え
 - BrowserBookmarkEntryList.tsのメソッドをcallback形式からPromiseに書き換え