### PR TITLE
Update: 検索の追加読み込み中に"検索中"を表示するように

### DIFF
--- a/src/_common.scss
+++ b/src/_common.scss
@@ -395,7 +395,7 @@ $z-indexes:(
     height: 0;
     flex-grow: 1;
     overflow-x: hidden;
-    overflow-y: scroll;
+    overflow-y: auto;
     position: relative;
     outline: none;
     scroll-snap-type: y mandatory;

--- a/src/view/search.coffee
+++ b/src/view/search.coffee
@@ -88,7 +88,7 @@ app.boot("/view/search.html", ["ThreadSearch"], (ThreadSearch) ->
   $buttonReload.on("click", ->
     return if $buttonReload.hasClass("disabled")
     threadList.empty()
-    threadSearch = new ThreadSearch(query)
+    threadSearch = new ThreadSearch(query, scheme)
     await load()
     onScroll() # 20件分がスクロールなしで表示できる場合
     $content.on("scroll", onScroll, passive: true)

--- a/src/view/search.coffee
+++ b/src/view/search.coffee
@@ -43,6 +43,7 @@ app.boot("/view/search.html", ["ThreadSearch"], (ThreadSearch) ->
     $view.addClass("loading")
     $buttonReload.addClass("disabled")
     $view.C("more")[0].textContent = "検索中"
+    $view.C("more")[0].removeClass("hidden")
     try
       result = await threadSearch.read()
       $messageBar.removeClass("error")


### PR DESCRIPTION
 - Update: 検索の追加読み込み中に"検索中"を表示するように
 - Fix: 検索をリロード後にスレが開けないのを修正
 - Fix: `overflow-y: auto`を既定値に
   - `overflow-y: scroll`だとオーバーレイスクロールがうまく効かない
   - autoでもscrollでも動作は変わらないので変更