### PR TITLE
Update: サブドメインなしのまちBBSに対応 close #502+α

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# read.crx 2 [![GitHub version](https://badge.fury.io/gh/readcrx-2%2Fread.crx-2.svg)][repolink] ![David Badge](https://david-dm.org/readcrx-2/read.crx-2/dev-status.svg "David Badge")
+# read.crx 2 [![GitHub version](https://badge.fury.io/gh/readcrx-2%2Fread.crx-2.svg)][repolink] ![David Badge](https://david-dm.org/readcrx-2/read.crx-2/dev-status.svg "David Badge") [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 read.crx 2は[Google Chrome][chrome]/[Firefox][firefox] extensionとして作られた2chブラウザです。
 [2ch.net(5ch.net)][5ch.net]、[2ch.sc][2ch.sc]、[open2ch.net][open2ch.net]及びその互換BBS、[まちBBS][machi]、[したらば][jbbs]の閲覧に対応しています。
 

--- a/src/background.coffee
+++ b/src/background.coffee
@@ -41,7 +41,7 @@ browser.runtime.onMessage.addListener( ({type}) ->
 # 対応URLのチェック
 supportedURL = ///https?:\/\/(?:
   (?:[\w\.]+\/test\/read\.cgi\/\w+\/\d+\/.*?)|
-  (?:\w+\.machi\.to\/bbs\/read\.cgi\/\w+\/\d+\/.*?)|
+  (?:(?:\w+\.)?machi\.to\/bbs\/read\.cgi\/\w+\/\d+\/.*?)|
   (?:jbbs\.(?:livedoor\.jp|shitaraba\.net)\/bbs\/read(?:_archive)?\.cgi\/\w+\/\d+\/\d+\/.*?)|
   (?:jbbs\.(?:livedoor\.jp|shitaraba\.net)\/\w+\/\d+\/storage\/\d+\.html$)|
   (?:[\w\.]+\/\w+\/(?:\#.*)?)|

--- a/src/core/BBSMenu.coffee
+++ b/src/core/BBSMenu.coffee
@@ -94,7 +94,7 @@ export get = (forceReload = false) ->
 parse = (html) ->
   regCategory = ///<b>(.+?)</b>(?:.*[\r\n]+<a\s.*?>.+?</a>)+///gi
   regBoard = ///<a\shref=(https?://(?!info\.[25]ch\.net/|headline\.bbspink\.com)
-    \w+\.(?:[25]ch\.net|machi\.to|open2ch\.net|2ch\.sc|bbspink\.com)/\w+/)(?:\s.*?)?>(.+?)</a>///gi
+    (?:\w+\.(?:[25]ch\.net|open2ch\.net|2ch\.sc|bbspink\.com)|(?:\w+\.)?machi\.to)/\w+/)(?:\s.*?)?>(.+?)</a>///gi
   menu = []
 
   while regCategoryRes = regCategory.exec(html)

--- a/src/core/Board.coffee
+++ b/src/core/Board.coffee
@@ -1,7 +1,7 @@
 import Cache from "./Cache.coffee"
 import {isNGBoard} from "./NG.coffee"
 import {Request} from "./HTTP.ts"
-import {tsld as getTsld, threadToBoard} from "./URL.ts"
+import {fix as fixUrl, tsld as getTsld, threadToBoard} from "./URL.ts"
 import {chServerMoveDetect, decodeCharReference, removeNeedlessFromTitle} from "./util.coffee"
 
 ###*
@@ -10,7 +10,13 @@ import {chServerMoveDetect, decodeCharReference, removeNeedlessFromTitle} from "
 @param {String} url
 ###
 export default class Board
-  constructor: (@url) ->
+  constructor: (url) ->
+    ###*
+    @property url
+    @type String
+    ###
+    @url = fixUrl(url)
+
     ###*
     @property thread
     @type Array | null

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -566,21 +566,24 @@ export default class Thread
   ###
   @_parseJbbsArchive = (text) ->
     # name, mail, other, message, thread_title
-    text = text.replace(/<dl><dt>/, "<dl>\n<dt>")
-    reg = /^<dt><a.*>\d+<\/a> ：(?:<a href="mailto:([^<>]*)">|<font [^>]*>)?<b>(.*)<\/b>.*：(.*)<dd> ?(.*)<br><br>$/
-    separator = "\n"
+    text = app.replaceAll(text, "\n", "")
+    text = text.replace(/<\/h1>\s*<dl>/, "</h1></dd><br><br>")
+    reg = /<dt[^>]*>\s*\d+ ：\s*(?:<a href="mailto:([^<>]*)">)?\s*(?:<font [^>]*>)?\s*<b>(.*)<\/b>.*：(.*)\s*<\/dt>\s*<dd>\s*(.*)\s*<br>/
+    separator = /<\/dd>[\s\n]*<br><br>/
 
-    titleReg = /<font size=.*?>(.*)\n?<\/font><\/b>/;
+    titleReg = /<h1>(.*)<\/h1>/;
     numberOfBroken = 0
     thread = res: []
     first = true
+    gotTitle = false
 
     for line in text.split(separator)
-      title = titleReg.exec(line)
+      title = if gotTitle then false else titleReg.exec(line)
       regRes = reg.exec(line)
 
       if title
         thread.title = decodeCharReference(title[1])
+        gotTitle = true
       else if regRes
         thread.res.push(
           name: regRes[2]

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -64,7 +64,10 @@ export default class Thread
           throw new Error("キャッシュの期限が切れているため通信します")
       catch
         #通信
-        if @tsld in ["shitaraba.net", "machi.to"]
+        if (
+          (@tsld is "shitaraba.net" and not @url.includes("/read_archive.cgi/")) or
+          @tsld is "machi.to"
+        )
           if hasCache
             deltaFlg = true
             xhrPath += (+cache.resLength + 1) + "-"

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -430,7 +430,6 @@ export default class Thread
   @_parseCh = (text) ->
     numberOfBroken = 0
     thread = res: []
-    first = true
 
     for line, key in text.split("\n")
       continue if line is ""
@@ -574,7 +573,6 @@ export default class Thread
     titleReg = /<h1>(.*)<\/h1>/;
     numberOfBroken = 0
     thread = res: []
-    first = true
     gotTitle = false
 
     for line in text.split(separator)
@@ -622,7 +620,6 @@ export default class Thread
     numberOfBroken = 0
     thread = res: []
     gotTitle = false
-    first = true
     resCount = resLength ? 0
 
     for line in text.split(separator)

--- a/src/core/Thread.coffee
+++ b/src/core/Thread.coffee
@@ -263,13 +263,26 @@ export default class Thread
             @message += "キャッシュに残っていたデータを表示します。"
           reject()
         else if @tsld is "shitaraba.net" and @url.includes("/read.cgi/")
-          newURL = @url.replace("/read.cgi/", "/read_archive.cgi/")
-          @message += """
-          スレッドの読み込みに失敗しました。
-          過去ログの可能性が有ります
-          (<a href="#{app.escapeHtml(app.safeHref(newURL))}"
-            class="open_in_rcrx">#{app.escapeHtml(newURL)}</a>)
-          """
+          @message += "スレッドの読み込みに失敗しました。"
+          {error} = response.headers
+          if error?
+            switch error
+              when "BBS NOT FOUND"
+                @message += "\nURLの掲示板番号が間違っています。"
+              when "KEY NOT FOUND"
+                @message += "\nURLのスレッド番号が間違っています。"
+              when "THREAD NOT FOUND"
+                @message += """
+                該当するスレッドは存在しません。
+                URLが間違っているか過去ログに移動せずに削除されています。
+                """
+              when "STORAGE IN"
+                newURL = @url.replace("/read.cgi/", "/read_archive.cgi/")
+                @message += """
+                過去ログが存在します
+                (<a href="#{app.escapeHtml(app.safeHref(newURL))}"
+                  class="open_in_rcrx">#{app.escapeHtml(newURL)}</a>)
+                """
           reject()
         else
           @message += "スレッドの読み込みに失敗しました。"

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -5,29 +5,29 @@ import {fetch as fetchBBSMenu} from "./BBSMenu.coffee"
 // @ts-ignore
 import Cache from "./Cache.coffee"
 
-export const CH_BOARD_REG = /^(https?:\/\/[\w\.]+\/(?:\w+\/)?test\/(?:read\.cgi|-)\/\w+\/\d+).*$/;
-export const CH_BOARD_REG2 = /^(https?:\/\/[\w\.]+\/\w+)\/?(?!test)$/;
-export const CH_BOARD_ULA_REG = /^(https?):\/\/ula\.5ch\.net\/2ch\/(\w+)\/([\w\.]+)\/(\d+).*$/;
-export const MACHI_BOARD_REG = /^(https?:\/\/\w+\.machi\.to\/bbs\/read\.cgi\/\w+\/\d+).*$/;
-export const SHITARABA_BOARD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(bbs\/read(?:_archive)?\.cgi\/\w+\/\d+\/\d+).*$/;
+export const CH_THREAD_REG = /^(https?:\/\/[\w\.]+\/(?:\w+\/)?test\/(?:read\.cgi|-)\/\w+\/\d+).*$/;
+export const CH_THREAD_REG2 = /^(https?:\/\/[\w\.]+\/\w+)\/?(?!test)$/;
+export const CH_THREAD_ULA_REG = /^(https?):\/\/ula\.5ch\.net\/2ch\/(\w+)\/([\w\.]+)\/(\d+).*$/;
+export const MACHI_THREAD_REG = /^(https?:\/\/\w+\.machi\.to\/bbs\/read\.cgi\/\w+\/\d+).*$/;
+export const SHITARABA_THREAD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(bbs\/read(?:_archive)?\.cgi\/\w+\/\d+\/\d+).*$/;
 export const SHITARABA_ARCHIVE_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+)\/storage\/(\d+)\.html$/;
-export const CH_THREAD_REG = /^(https?:\/\/[\w\.]+\/(?:subback\/|test\/-\/)?\w+\/)(?:#.*)?$/;
-export const SHITARABA_THREAD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+\/)(?:#.*)?$/;
+export const CH_BOARD_REG = /^(https?:\/\/[\w\.]+\/(?:subback\/|test\/-\/)?\w+\/)(?:#.*)?$/;
+export const SHITARABA_BOARD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+\/)(?:#.*)?$/;
 export function fix (url:string):string {
   return (
     url
       //2ch.net->5ch.net
       .replace(/^(https?):\/\/(\w+)\.2ch\.net\//, "$1://$2.5ch.net/")
       // スレ系 誤爆する事は考えられないので、パラメータ部分をバッサリ切ってしまう
-      .replace(CH_BOARD_REG, "$1/")
-      .replace(CH_BOARD_REG2, "$1/")
-      .replace(CH_BOARD_ULA_REG, "$1://$3/test/read.cgi/$2/$4/")
-      .replace(MACHI_BOARD_REG, "$1/")
-      .replace(SHITARABA_BOARD_REG, "$1://jbbs.shitaraba.net/$2/")
+      .replace(CH_THREAD_REG, "$1/")
+      .replace(CH_THREAD_REG2, "$1/")
+      .replace(CH_THREAD_ULA_REG, "$1://$3/test/read.cgi/$2/$4/")
+      .replace(MACHI_THREAD_REG, "$1/")
+      .replace(SHITARABA_THREAD_REG, "$1://jbbs.shitaraba.net/$2/")
       .replace(SHITARABA_ARCHIVE_REG, "$1://jbbs.shitaraba.net/bbs/read_archive.cgi/$2/$3/")
       // 板系 完全に誤爆を少しでも減らすために、パラメータ形式も限定する
-      .replace(CH_THREAD_REG, "$1")
-      .replace(SHITARABA_THREAD_REG, "$1://jbbs.shitaraba.net/$2")
+      .replace(CH_BOARD_REG, "$1")
+      .replace(SHITARABA_BOARD_REG, "$1://jbbs.shitaraba.net/$2")
   );
 }
 

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -8,11 +8,12 @@ import Cache from "./Cache.coffee"
 export const CH_THREAD_REG = /^(https?:\/\/[\w\.]+\/(?:\w+\/)?test\/(?:read\.cgi|-)\/\w+\/\d+).*$/;
 export const CH_THREAD_REG2 = /^(https?:\/\/[\w\.]+\/\w+)\/?(?!test)$/;
 export const CH_THREAD_ULA_REG = /^(https?):\/\/ula\.5ch\.net\/2ch\/(\w+)\/([\w\.]+)\/(\d+).*$/;
-export const MACHI_THREAD_REG = /^(https?:\/\/\w+\.machi\.to\/bbs\/read\.cgi\/\w+\/\d+).*$/;
+export const MACHI_THREAD_REG = /^(https?):\/\/(?:\w+\.)?machi\.to\/bbs\/read\.cgi\/(\w+\/\d+).*$/;
 export const SHITARABA_THREAD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(bbs\/read(?:_archive)?\.cgi\/\w+\/\d+\/\d+).*$/;
 export const SHITARABA_ARCHIVE_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+)\/storage\/(\d+)\.html$/;
-export const CH_BOARD_REG = /^(https?:\/\/[\w\.]+\/(?:subback\/|test\/-\/)?\w+\/)(?:#.*)?$/;
+export const MACHI_BOARD_REG = /^(https?):\/\/(?:\w+\.)?machi\.to\/(\w+\/)(?:#.*)?$/;
 export const SHITARABA_BOARD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+\/)(?:#.*)?$/;
+export const CH_BOARD_REG = /^(https?:\/\/[\w\.]+\/(?:subback\/|test\/-\/)?\w+\/)(?:#.*)?$/;
 export function fix (url:string):string {
   return (
     url
@@ -22,12 +23,13 @@ export function fix (url:string):string {
       .replace(CH_THREAD_REG, "$1/")
       .replace(CH_THREAD_REG2, "$1/")
       .replace(CH_THREAD_ULA_REG, "$1://$3/test/read.cgi/$2/$4/")
-      .replace(MACHI_THREAD_REG, "$1/")
+      .replace(MACHI_THREAD_REG, "$1://machi.to/bbs/read.cgi/$2/")
       .replace(SHITARABA_THREAD_REG, "$1://jbbs.shitaraba.net/$2/")
       .replace(SHITARABA_ARCHIVE_REG, "$1://jbbs.shitaraba.net/bbs/read_archive.cgi/$2/$3/")
       // 板系 完全に誤爆を少しでも減らすために、パラメータ形式も限定する
-      .replace(CH_BOARD_REG, "$1")
+      .replace(MACHI_BOARD_REG, "$1://machi.to/$2")
       .replace(SHITARABA_BOARD_REG, "$1://jbbs.shitaraba.net/$2")
+      .replace(CH_BOARD_REG, "$1")
   );
 }
 
@@ -44,10 +46,10 @@ export function guessType (url:string):GuessResult {
   else if (/^https?:\/\/jbbs\.shitaraba\.net\/\w+\/\d+\/$/.test(url)) {
     return {type: "board", bbsType: "jbbs"};
   }
-  else if (/^https?:\/\/\w+\.machi\.to\/bbs\/read\.cgi\/\w+\/\d+\/$/.test(url)) {
+  else if (/^https?:\/\/(?:\w+\.)?machi\.to\/bbs\/read\.cgi\/\w+\/\d+\/$/.test(url)) {
     return {type: "thread", bbsType: "machi"};
   }
-  else if (/^https?:\/\/\w+\.machi\.to\/\w+\/$/.test(url)) {
+  else if (/^https?:\/\/(?:\w+\.)?machi\.to\/\w+\/$/.test(url)) {
     return {type: "board", bbsType: "machi"};
   }
   else if (/^https?:\/\/[\w\.]+\/(?:\w+\/)?test\/(?:read\.cgi|-)\/\w+\/\d+\/$/.test(url)) {
@@ -111,7 +113,7 @@ export function getResNumber (urlstr: string): string|null {
   if (tmp !== null) {
     return tmp[1];
   }
-  tmp = /^https?:\/\/\w+\.machi\.to\/bbs\/read\.cgi\/\w+\/\d+\/(\d+).*$/.exec(urlstr);
+  tmp = /^https?:\/\/(?:\w+\.)?machi\.to\/bbs\/read\.cgi\/\w+\/\d+\/(\d+).*$/.exec(urlstr);
   if (tmp !== null) {
     return tmp[1];
   }

--- a/src/cs_addlink.coffee
+++ b/src/cs_addlink.coffee
@@ -7,8 +7,8 @@ reg = ///^https?://(?:
   (?:jbbs\.shitaraba\.net/\w+/\d+/(?:index\.html)?(?:#\d+)?$)|
   (?:jbbs\.shitaraba\.net/bbs/read(?:_archive)?\.cgi/\w+/\d+/\d+)|
   (?:jbbs\.shitaraba\.net/\w+/\d+/storage/\d+\.html)|
-  (?:\w+\.machi\.to/\w+/(?:index\.html)?(?:#\d+)?$)|
-  (?:\w+\.machi\.to/bbs/read\.cgi/\w+/\d+)
+  (?:(?:\w+\.)?machi\.to/\w+/(?:index\.html)?(?:#\d+)?$)|
+  (?:(?:\w+\.)?machi\.to/bbs/read\.cgi/\w+/\d+)
   )
   ///
 


### PR DESCRIPTION
 - Update: サブドメインなしのまちBBSに対応 close #502
   - まちBBSの既読情報が消えてしまう
 - Update: README.mdにMITライセンスバッジを追加
 - Fix: したらばの読み込みエラーメッセージを改善
 - Fix: したらばの過去ログが読み込めないのを修正
 - Fix: したらばの過去ログをリロードすると重複してレスが追加されるのを修正