### PR TITLE
Fix: 検索モードの保管タイミングを変更など

### DIFF
--- a/src/view/search.coffee
+++ b/src/view/search.coffee
@@ -96,12 +96,8 @@ app.boot("/view/search.html", ["ThreadSearch"], (ThreadSearch) ->
     return
   )
 
-  window.on("view_unload", ->
-    app.config.set("thread_search_last_mode", scheme)
-    return
-  )
-
   await load()
   onScroll() # 20件分がスクロールなしで表示できる場合
+  app.config.set("thread_search_last_mode", scheme)
   return
 )


### PR DESCRIPTION
```
719名無しさんsage2018/10/04(木) 17:23:55ID:5HxQgJOU(1/1)
検索して出てきたタブをhttpsに替えてread.crxを終了して
再度、起動したらhttpに戻ってしまいます
```
- 検索モードの保管タイミングを変更
保管タイミングを`unload`時ではなく、描画終了時に変更しました。

- 未読数が0になった時点で一旦既読情報を保管する
ブラウザの異常終了時などに既読情報が失われるのを少しでも防ぐため、未読数が0になったタイミングでも保管するようにしてみました。