### PR TITLE
Fix: NGが反映されないケースがある close #507

### DIFF
--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -202,11 +202,20 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
 
   whenClose = ->
     #NG設定
-    app.NG.set($view.$("textarea[name=\"ngwords\"]").value)
+    dom = $view.$("textarea[name=\"ngwords\"]")
+    if dom.getAttr("changed")?
+      dom.removeAttr("changed")
+      app.NG.set(dom.value)
     #ImageReplaceDat設定
-    app.ImageReplaceDat.set($view.$("textarea[name=\"image_replace_dat\"]").value)
+    dom = $view.$("textarea[name=\"image_replace_dat\"]")
+    if dom.getAttr("changed")?
+      dom.removeAttr("changed")
+      app.ImageReplaceDat.set(dom.value)
     #ReplaceStrTxt設定
-    app.ReplaceStrTxt.set($view.$("textarea[name=\"replace_str_txt\"]").value)
+    dom = $view.$("textarea[name=\"replace_str_txt\"]")
+    if dom.getAttr("changed")?
+      dom.removeAttr("changed")
+      app.ReplaceStrTxt.set(dom.value)
     return
 
   #閉じるボタン
@@ -217,7 +226,7 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
     return
   )
 
-  window.on("view_unload", ->
+  window.on("beforeunload", ->
     whenClose()
     return
   )
@@ -234,6 +243,7 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
     dom.value = app.config.get(dom.name) or ""
     dom.on("input", ->
       app.config.set(@name, @value)
+      @setAttr("changed", "true")
       return
     )
 


### PR DESCRIPTION
read.crx自体のリロードやクローズの際には`view_unload`が届かない(`index.html`より先にクローズされるため?)ので、直接`beforeunload`を受け取るようにしました。(何故か`unload`では上手く行かなかったので)
また、登録処理の2重実行を避けるために、各テキストエリアの属性に一時的な変更フラグを追加しました。