### PR TITLE
板一覧の取得に関する仕様変更

### DIFF
--- a/src/app/Config.ts
+++ b/src/app/Config.ts
@@ -76,6 +76,7 @@ export default class Config {
     ["user_css", ""],
     ["bbsmenu", "https://menu.5ch.net/bbsmenu.html\nhttps://menu.2ch.sc/bbsmenu.html\nhttps://menu.open2ch.net/bbsmenu.html\n"],
     ["bbsmenu_update_interval", "7"],
+    ["bbsmenu_option", ""],
     ["useragent", ""],
     ["format_2chnet", "html"],
     ["sage_flag", "on"],

--- a/src/app/Config.ts
+++ b/src/app/Config.ts
@@ -74,7 +74,7 @@ export default class Config {
     ["no_history", "off"],
     ["no_writehistory", "off"],
     ["user_css", ""],
-    ["bbsmenu", "http://kita.jikkyo.org/cbm/cbm.cgi/5r.p5.m0.op.sc.99/-all/bbsmenu.html"],
+    ["bbsmenu", "https://menu.5ch.net/bbsmenu.html"],
     ["bbsmenu_update_interval", "7"],
     ["useragent", ""],
     ["format_2chnet", "html"],

--- a/src/app/Config.ts
+++ b/src/app/Config.ts
@@ -74,7 +74,7 @@ export default class Config {
     ["no_history", "off"],
     ["no_writehistory", "off"],
     ["user_css", ""],
-    ["bbsmenu", "https://menu.5ch.net/bbsmenu.html"],
+    ["bbsmenu", "https://menu.5ch.net/bbsmenu.html\nhttps://menu.2ch.sc/bbsmenu.html\nhttps://menu.open2ch.net/bbsmenu.html\n"],
     ["bbsmenu_update_interval", "7"],
     ["useragent", ""],
     ["format_2chnet", "html"],

--- a/src/core/BBSMenu.coffee
+++ b/src/core/BBSMenu.coffee
@@ -1,6 +1,8 @@
 import Cache from "./Cache.coffee"
 import {Request} from "./HTTP.ts"
 
+bbsmenuOption = null
+
 export target = $__("div")
 
 ###*
@@ -9,6 +11,16 @@ export target = $__("div")
 ###
 export fetchAll = (forceReload = false) ->
   bbsmenu = []
+
+  if !bbsmenuOption or forceReload
+    unless bbsmenuOption
+      bbsmenuOption = new Set()
+    else
+      bbsmenuOption.clear()
+    tmpOpt = app.config.get("bbsmenu_option").split("\n")
+    for opt in tmpOpt
+      continue if opt is "" or opt.startsWith("//")
+      bbsmenuOption.add(opt)
 
   bbsmenuUrl = app.config.get("bbsmenu").split("\n")
   for url in bbsmenuUrl
@@ -111,6 +123,7 @@ parse = (html) ->
   regBoard = ///<a\shref=(https?://(?!info\.[25]ch\.net/|headline\.bbspink\.com)
     (?:\w+\.(?:[25]ch\.net|open2ch\.net|2ch\.sc|bbspink\.com)|(?:\w+\.)?machi\.to)/\w+/)(?:\s.*?)?>(.+?)</a>///gi
   menu = []
+  bbspinkException = bbsmenuOption.has("bbspink.com")
 
   while regCategoryRes = regCategory.exec(html)
     category =
@@ -119,6 +132,8 @@ parse = (html) ->
 
     subName = null
     while regBoardRes = regBoard.exec(regCategoryRes[0])
+      continue if bbsmenuOption.has(app.URL.tsld(regBoardRes[1]))
+      continue if bbspinkException and regBoardRes[1].includes("5ch.net/bbypink")
       unless subName
         if regBoardRes[1].includes("open2ch.net")
           subName = "op"

--- a/src/core/BBSMenu.coffee
+++ b/src/core/BBSMenu.coffee
@@ -1,9 +1,29 @@
 import Cache from "./Cache.coffee"
 import {Request} from "./HTTP.ts"
 
-data = null
-
 export target = $__("div")
+
+###*
+@method fetchAll
+@param {Boolean} [forceReload=false]
+###
+export fetchAll = (forceReload = false) ->
+  bbsmenu = []
+
+  bbsmenuUrl = app.config.get("bbsmenu").split("\n")
+  for url in bbsmenuUrl
+    continue if url is "" or url.startsWith("//")
+    try
+      {menu} = await fetch(url, forceReload)
+      for item in menu
+        bbsmenu.push(item)
+    catch
+      app.message.send("notify",
+        message: "板一覧の取得に失敗しました。(#{url})"
+        background_color: "red"
+      )
+
+  return {menu: bbsmenu}
 
 ###*
 @method fetch
@@ -11,8 +31,6 @@ export target = $__("div")
 @param {Boolean} [force=false]
 ###
 export fetch = (url, force) ->
-  if data? and not force
-    return data.content
   #キャッシュ取得
   cache = new Cache(url)
 
@@ -58,14 +76,11 @@ export fetch = (url, force) ->
       cache.put()
 
   unless menu?.length > 0
-    data = {content: {response}, success: false}
     throw {response}
 
   unless response?.status is 200 or response?.status is 304 or (not response and cache.data?)
-    data = {content: {response, menu}, success: false}
     throw {response, menu}
 
-  data = {content: {response, menu}, success: true}
   return {response, menu}
 
 ###*
@@ -134,15 +149,6 @@ parse = (html) ->
 
 _updatingPromise = null
 _update = (forceReload) ->
-  try
-    {menu} = await fetch(app.config.get("bbsmenu"), forceReload)
-  catch {menu}
-    message = "板一覧の取得に失敗しました。"
-    if menu?
-      message += "キャッシュに残っていたデータを表示します。"
-      throw {menu, message}
-    else
-      throw {message}
-  finally
-    _updatingPromise = null
+  {menu} = await fetchAll(forceReload)
+  _updatingPromise = null
   return {menu}

--- a/src/core/BBSMenu.coffee
+++ b/src/core/BBSMenu.coffee
@@ -102,7 +102,27 @@ parse = (html) ->
       title: regCategoryRes[1]
       board: []
 
+    subName = null
     while regBoardRes = regBoard.exec(regCategoryRes[0])
+      unless subName
+        if regBoardRes[1].includes("open2ch.net")
+          subName = "op"
+        else if regBoardRes[1].includes("2ch.sc")
+          subName = "sc"
+        else
+          subName = ""
+        if (
+          subName isnt "" and
+          !(category.title.endsWith("(#{subName})") or
+            category.title.endsWith("_#{subName}"))
+        )
+          category.title += "(#{subName})"
+      if (
+        subName isnt "" and
+        !(regBoardRes[2].endsWith("(#{subName})") or
+          regBoardRes[2].endsWith("_#{subName}"))
+      )
+        regBoardRes[2] += "_#{subName}"
       category.board.push(
         url: regBoardRes[1]
         title: regBoardRes[2]

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -396,6 +396,12 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
     if dom.getAttr("changed")?
       dom.removeAttr("changed")
       app.ReplaceStrTxt.set(dom.value)
+    #bbsmenu設定
+    dom = $view.$("textarea[name=\"bbsmenu\"]")
+    if dom.getAttr("changed")?
+      dom.removeAttr("changed")
+      app.config.set("bbsmenu", dom.value)
+      $view.C("bbsmenu_reload")[0].click()
     return
 
   #閉じるボタン
@@ -491,6 +497,9 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
     $button.disabled = true
     $status.setClass("loading")
     $status.textContent = "更新中"
+    dom = $view.$("textarea[name=\"bbsmenu\"]")
+    dom.removeAttr("changed")
+    app.config.set("bbsmenu", dom.value)
 
     try
       await BBSMenu.get(true)
@@ -683,20 +692,12 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
   #bbsmenu設定
   resetBBSMenu = ->
     await app.config.del("bbsmenu")
-    $view.$(".direct.bbsmenu").value = app.config.get("bbsmenu")
+    $view.$("textarea[name=\"bbsmenu\"]").value = app.config.get("bbsmenu")
     $$.C("bbsmenu_reload")[0].click()
     return
 
-  if $view.$(".direct.bbsmenu").value is ""
+  if $view.$("textarea[name=\"bbsmenu\"]").value is ""
     resetBBSMenu()
-
-  $view.$(".direct.bbsmenu").on("change", ->
-    if $view.$(".direct.bbsmenu").value isnt ""
-      $$.C("bbsmenu_reload")[0].click()
-    else
-      resetBBSMenu()
-    return
-  )
 
   $view.C("bbsmenu_reset")[0].on("click", ->
     resetBBSMenu()

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -397,10 +397,18 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
       dom.removeAttr("changed")
       app.ReplaceStrTxt.set(dom.value)
     #bbsmenu設定
+    changeFlag = false
     dom = $view.$("textarea[name=\"bbsmenu\"]")
     if dom.getAttr("changed")?
       dom.removeAttr("changed")
       app.config.set("bbsmenu", dom.value)
+      changeFlag = true
+    dom = $view.$("textarea[name=\"bbsmenu_option\"]")
+    if dom.getAttr("changed")?
+      dom.removeAttr("changed")
+      app.config.set("bbsmenu_option", dom.value)
+      changeFlag = true
+    if changeFlag
       $view.C("bbsmenu_reload")[0].click()
     return
 
@@ -500,6 +508,9 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
     dom = $view.$("textarea[name=\"bbsmenu\"]")
     dom.removeAttr("changed")
     app.config.set("bbsmenu", dom.value)
+    dom = $view.$("textarea[name=\"bbsmenu_option\"]")
+    dom.removeAttr("changed")
+    app.config.set("bbsmenu_option", dom.value)
 
     try
       await BBSMenu.get(true)

--- a/src/view/config/_other.pug
+++ b/src/view/config/_other.pug
@@ -8,7 +8,10 @@
       div: input.direct(type="text" name="default_mail")
 
   section
-    h2 板一覧
+    h2
+      |板一覧(
+      a(href="https://github.com/readcrx-2/read.crx-2/wiki/bbsmenu%E3%81%AE%E4%BB%95%E6%A7%98" target="_blank") 詳細
+      |)
     div
       button.bbsmenu_reload(type="button") 更新
       span#bbsmenu_reload_status
@@ -17,10 +20,12 @@
       input.direct.days(type="number" name="bbsmenu_update_interval" min="1" value="7")
       |日
       br
-      |URL(
-      a(href="https://github.com/readcrx-2/read.crx-2/wiki/bbsmenu%E3%81%AE%E4%BB%95%E6%A7%98" target="_blank") 詳細
-      |):
-      input.direct.bbsmenu(type="text" name="bbsmenu")
+      |URL:
+      br
+      |1行に1つのURLを指定できます
+      br
+      textarea.direct(name="bbsmenu" rows="6" cols="80")
+      br
       button.bbsmenu_reset(type="button") リセット
 
   section

--- a/src/view/config/_other.pug
+++ b/src/view/config/_other.pug
@@ -18,7 +18,7 @@
       |日
       br
       |URL(
-      a(href="http://kita.jikkyo.org/cbm/" target="_blank") 詳細
+      a(href="https://github.com/readcrx-2/read.crx-2/wiki/bbsmenu%E3%81%AE%E4%BB%95%E6%A7%98" target="_blank") 詳細
       |):
       input.direct.bbsmenu(type="text" name="bbsmenu")
       button.bbsmenu_reset(type="button") リセット

--- a/src/view/config/_other.pug
+++ b/src/view/config/_other.pug
@@ -27,6 +27,10 @@
       textarea.direct(name="bbsmenu" rows="6" cols="80")
       br
       button.bbsmenu_reset(type="button") リセット
+      br
+      |メニューに表示したくないドメインを1行に1つ指定できます
+      br
+      textarea.direct(name="bbsmenu_option" rows="4" cols="80")
 
   section
     h2 その他

--- a/src/view/index.coffee
+++ b/src/view/index.coffee
@@ -301,9 +301,9 @@ app.boot("/view/index.html", ["BBSMenu"], (BBSMenu) ->
   app.main()
 
   {menu} = await BBSMenu.get()
-  await app.URL.pushServerInfo(app.config.get("bbsmenu"), menu)
+  await app.URL.pushServerInfo(menu)
   BBSMenu.target.on("change", ({detail: {menu}}) ->
-    app.URL.pushServerInfo(app.config.get("bbsmenu"), menu)
+    app.URL.pushServerInfo(menu)
   )
 
   return unless query


### PR DESCRIPTION
jikkyo.orgの閉鎖に伴う仕様変更を行いました。また、表示制御のためのオプションを追加しました。

wiki文案
URL
 - 1行に1つのURLを指定します。
 - `//`で始まる行はコメントとして無視します。
 - https://egg.5ch.net/test/read.cgi/software/1339477664/ の845さんが用意された http://kyoran.php.xdomain.jp/readcrx/bbsmenu.html も使用することが出来ます。

例)
```
// 5chとbbspink
https://menu.5ch.net/bbsmenu.html
// 2ch.scとまちBBS
https://menu.2ch.sc/bbsmenu.html
// おーぷん2ちゃんねる
https://menu.open2ch.net/bbsmenu.html

// または
http://kyoran.php.xdomain.jp/readcrx/bbsmenu.html
```

メニューから除外するドメインの指定
 - メニューに表示したくないドメインを1行に1つ指定します。
 - `//`で始まる行はコメントとして無視します。

例)
```
// 5chは表示するがbbspinkは表示しない
bbspink.com

// まちBBSは表示するが2ch.scは表示しない
2ch.sc
```