### PR TITLE
Update: 初期値を持つ設定のリセットを可能にするなど

### DIFF
--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -711,6 +711,10 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
     resetBBSMenu()
 
   $view.C("bbsmenu_reset")[0].on("click", ->
+    result = await UI.Dialog("confirm",
+      message: "設定内容をリセットします。よろしいですか？"
+    )
+    return unless result
     resetBBSMenu()
     return
   )

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -738,6 +738,44 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
     )
     $dom.emit(new Event("change"))
 
+  # ImageReplaceDatのリセット
+  $view.C("dat_file_reset")[0].on("click", ->
+    result = await UI.Dialog("confirm",
+      message: "設定内容をリセットします。よろしいですか？"
+    )
+    return unless result
+    await app.config.del("image_replace_dat")
+    resetData = app.config.get("image_replace_dat")
+    $view.$("textarea[name=\"image_replace_dat\"]").value = resetData
+    app.ImageReplaceDat.set(resetData)
+    return
+  )
+
+  # ぼかし判定用正規表現のリセット
+  $view.C("image_blur_reset")[0].on("click", ->
+    result = await UI.Dialog("confirm",
+      message: "設定内容をリセットします。よろしいですか？"
+    )
+    return unless result
+    await app.config.del("image_blur_word")
+    resetData = app.config.get("image_blur_word")
+    $view.$("input[name=\"image_blur_word\"]").value = resetData
+    return
+  )
+
+  # NG設定のリセット
+  $view.C("ngwords_reset")[0].on("click", ->
+    result = await UI.Dialog("confirm",
+      message: "設定内容をリセットします。よろしいですか？"
+    )
+    return unless result
+    await app.config.del("ngwords")
+    resetData = app.config.get("ngwords")
+    $view.$("textarea[name=\"ngwords\"]").value = resetData
+    app.NG.set(resetData)
+    return
+  )
+
   # 設定をインポート/エクスポート
   new SettingIO(
     name: "config"

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -635,6 +635,12 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
 
     $clearButton.on("click", ->
       return unless _checkExcute("cache", "clear")
+      result = await UI.Dialog("confirm",
+        message: "本当に削除しますか？"
+      )
+      unless result
+        _clearExcute()
+        return
       $status.textContent = ":削除中"
 
       try
@@ -652,6 +658,12 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
     $clearRangeButton = $view.C("cache_range_clear")[0]
     $clearRangeButton.on("click", ->
       return unless _checkExcute("cache", "clear_range")
+      result = await UI.Dialog("confirm",
+        message: "本当に削除しますか？"
+      )
+      unless result
+        _clearExcute()
+        return
       $status.textContent = ":範囲指定削除中"
 
       try

--- a/src/view/config/_ng.pug
+++ b/src/view/config/_ng.pug
@@ -11,6 +11,8 @@
       br
       label
         textarea.direct(name="ngwords" rows="6" cols="80")
+      br
+      button.ngwords_reset(type="button") リセット
 
   section
     h2 連鎖設定

--- a/src/view/config/_thumbnail.pug
+++ b/src/view/config/_thumbnail.pug
@@ -20,6 +20,8 @@
       button.dat_file_show(type="button") ファイル読み込み(UTF-8)
       button.dat_import_button(type="button") インポート
       span#dat_status
+      br
+      button.dat_file_reset(type="button") リセット
 
   section
     h2 ぼかし設定
@@ -37,6 +39,7 @@
       label
         |判定正規表現:
         input.direct.image_blur_word(type="text" name="image_blur_word")
+      button.image_blur_reset(type="button") リセット
   section
     h2 サムネイルサイズ
     div


### PR DESCRIPTION
 - 初期値を持つ設定項目のリセットを可能にする
 - キャッシュの削除ボタンにも確認画面を追加する
 - 板一覧のリセットボタンに確認画面を追加する

以上、修正しました。