### PR TITLE
Fix: Chrome72～でリファラエラーで書き込めないのを修正

### DIFF
--- a/src/write/submit_res.coffee
+++ b/src/write/submit_res.coffee
@@ -12,6 +12,10 @@ class SubmitRes extends Write
 
   _setHeaderModifier: ->
     {id} = await browser.tabs.getCurrent()
+    extraInfoSpec = ["requestHeaders", "blocking"]
+    if browser.webRequest.OnBeforeSendHeadersOptions.hasOwnProperty("EXTRA_HEADERS")
+      extraInfoSpec.push("extraHeaders")
+
     browser.webRequest.onBeforeSendHeaders.addListener(
       @_beforeSendFunc()
       {
@@ -22,7 +26,7 @@ class SubmitRes extends Write
           "*://jbbs.shitaraba.net/bbs/write.cgi/*"
         ]
       }
-      ["requestHeaders", "blocking"]
+      extraInfoSpec
     )
     browser.webRequest.onHeadersReceived.addListener( ({responseHeaders}) ->
       # X-Frame-Options回避

--- a/src/write/submit_thread.coffee
+++ b/src/write/submit_thread.coffee
@@ -12,6 +12,10 @@ class SubmitThread extends Write
 
   _setHeaderModifier: ->
     {id} = await browser.tabs.getCurrent()
+    extraInfoSpec = ["requestHeaders", "blocking"]
+    if browser.webRequest.OnBeforeSendHeadersOptions.hasOwnProperty("EXTRA_HEADERS")
+      extraInfoSpec.push("extraHeaders")
+
     browser.webRequest.onBeforeSendHeaders.addListener(
       @_beforeSendFunc()
       {
@@ -25,7 +29,7 @@ class SubmitThread extends Write
           "*://jbbs.shitaraba.net/bbs/write.cgi/*"
         ]
       }
-      ["requestHeaders", "blocking"]
+      extraInfoSpec
     )
     return
 

--- a/src/write/write.coffee
+++ b/src/write/write.coffee
@@ -71,14 +71,25 @@ export default class Write
       return unless method is "POST" and isSameOrigin
       if getTsld(url) is "2ch.sc"
         url = setScheme(url, "http")
-      requestHeaders.push(name: "Referer", value: url)
 
-      # UA変更処理
       ua = app.config.get("useragent").trim()
-      if ua.length > 0
-        for {name}, i in requestHeaders when name is "User-Agent"
+      uaExists = (ua.length > 0)
+      setReferer = false
+      setUserAgent = !uaExists
+
+      for {name}, i in requestHeaders
+        if !setReferer and name is "Referer"
+          requestHeaders[i].value = url
+          setReferer = true
+        else if !setUserAgent and name is "User-Agent"
           requestHeaders[i].value = ua
-          break
+          setUserAgent = true
+        break if setReferer and setUserAgent
+
+      if not setReferer
+        requestHeaders.push(name: "Referer", value: url)
+      if not setUserAgent and uaExists
+        requestHeaders.push(name: "User-Agent", value: ua)
 
       return {requestHeaders}
 


### PR DESCRIPTION
 - Fix: Chrome72～でリファラエラーで書き込めないのを修正

[chrome.webRequest - Google Chrome](https://developer.chrome.com/extensions/webRequest#event-onBeforeSendHeaders)
> Starting from **Chrome 72**, the Set-Cookie response header is not provided and **cannot be modified or removed without specifying 'extraHeaders'** in opt_extraInfoSpec.

 - Fix: User-Agentがついていない/Refererが最初からついている場合でも書き込みが正常にできるように修正