### PR TITLE
Fix: .tsのリファクタリング&バグ修正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,24 +7,22 @@ export * from "./app/Log";
 export {default as message} from "./app/Message";
 export * from "./app/Util";
 
-export var config: Config;
+export let config: Config;
 if (!frameElement) {
   config = new Config();
 }
 
-export var manifest = (async () => {
-  if (/^(?:chrome|moz)-extension:\/\//.test(location.origin)) {
-    try {
-      let response = await fetch("/manifest.json");
-      return await response.json();
-    } catch {}
+export const manifest = (async () => {
+  if (!/^(?:chrome|moz)-extension:\/\//.test(location.origin)) {
+    throw new Error("manifest.jsonの取得に失敗しました");
   }
-  throw new Error("manifest.jsonの取得に失敗しました");
+  try {
+    const response = await fetch("/manifest.json");
+    return await response.json();
+  } catch {}
 })();
 
-export async function boot (path:string, requirements, fn): Promise<void> {
-  var htmlVersion:string;
-
+export async function boot(path: string, requirements, fn) {
   if (!fn) {
     fn = requirements;
     requirements = null;
@@ -40,29 +38,32 @@ export async function boot (path:string, requirements, fn): Promise<void> {
   }
 
   if (location.pathname === path) {
-    htmlVersion = document.documentElement.dataset.appVersion!;
+    const htmlVersion = document.documentElement.dataset.appVersion!;
     if ((await manifest).version !== htmlVersion) {
       location.reload(true);
+      return;
+    }
+
+    const onload = () => {
+      config.ready( () => {
+        if (!requirements) {
+          fn();
+          return;
+        }
+
+        const modules: any[] = [];
+        for (const module of <string[]>requirements) {
+          modules.push(parent.app[module]);
+        }
+        fn(...modules);
+      });
+    };
+
+    // async関数のためDOMContentLoadedに間に合わないことがある
+    if (document.readyState === "loading") {
+      document.on("DOMContentLoaded", onload);
     } else {
-      let onload = () => {
-        config.ready( () => {
-          if (requirements) {
-            let modules: any[] = [];
-            for (let module of <string[]>requirements) {
-              modules.push(parent.app[module]);
-            }
-            fn(...modules);
-          } else {
-            fn();
-          }
-        });
-      };
-      // async関数のためDOMContentLoadedに間に合わないことがある
-      if (document.readyState === "loading") {
-        document.on("DOMContentLoaded", onload);
-      } else {
-        onload();
-      }
+      onload();
     }
   }
 }

--- a/src/app/Callbacks.ts
+++ b/src/app/Callbacks.ts
@@ -11,11 +11,11 @@ export default class Callbacks {
   private _latestCallArg: any[]|null = null;
   wasCalled = false;
 
-  constructor (config:CallbacksConfiguration = {}) {
+  constructor(config: CallbacksConfiguration = {}) {
     this._config = config;
   }
 
-  add (callback:Function):void {
+  add(callback: Function) {
     if (!this._config.persistent && this._latestCallArg) {
       callback(...deepCopy(this._latestCallArg));
     } else {
@@ -23,7 +23,7 @@ export default class Callbacks {
     }
   }
 
-  remove (callback:Function):void {
+  remove(callback: Function) {
     if (this._callbackStore.has(callback)) {
       this._callbackStore.delete(callback);
     } else {
@@ -32,32 +32,29 @@ export default class Callbacks {
     }
   }
 
-  call (...arg:any[]):void {
-    var callback:Function, tmpCallbackStore;
-
+  call(...arg: any[]) {
     if (!this._config.persistent && this._latestCallArg) {
       log("error",
         "app.Callbacks: persistentでないCallbacksが複数回callされました。");
-    } else {
-      this.wasCalled = true;
+      return;
+    }
 
-      this._latestCallArg = deepCopy(arg);
+    this.wasCalled = true;
+    this._latestCallArg = deepCopy(arg);
+    const tmpCallbackStore = new Set(this._callbackStore);
 
-      tmpCallbackStore = new Set(this._callbackStore);
-
-      for (callback of tmpCallbackStore) {
-        if (this._callbackStore.has(callback)) {
-          callback(...deepCopy(arg));
-        }
+    for (const callback of tmpCallbackStore) {
+      if (this._callbackStore.has(callback)) {
+        callback(...deepCopy(arg));
       }
+    }
 
-      if (!this._config.persistent) {
-        this._callbackStore.clear();
-      }
+    if (!this._config.persistent) {
+      this._callbackStore.clear();
     }
   }
 
-  destroy ():void {
+  destroy() {
     this._callbackStore.clear();
   }
 }

--- a/src/app/Callbacks.ts
+++ b/src/app/Callbacks.ts
@@ -6,9 +6,9 @@ interface CallbacksConfiguration {
 }
 
 export default class Callbacks {
-  private _config: CallbacksConfiguration;
-  private _callbackStore = new Set<Function>();
-  private _latestCallArg: any[]|null = null;
+  private readonly _config: Readonly<CallbacksConfiguration>;
+  private readonly _callbackStore = new Set<Function>();
+  private _latestCallArg: ReadonlyArray<any>|null = null;
   wasCalled = false;
 
   constructor(config: CallbacksConfiguration = {}) {

--- a/src/app/Config.ts
+++ b/src/app/Config.ts
@@ -89,17 +89,16 @@ export default class Config {
 
   private _cache = new Map<string, string>();
   ready: Function;
-  _onChanged: any;
+  _onChanged: Function;
 
-  constructor () {
-    var ready = new Callbacks();
+  constructor() {
+    const ready = new Callbacks();
     this.ready = ready.add.bind(ready);
 
     ( async () => {
-      var key:string, val:any;
-      var res = await browser.storage.local.get(null);
+      const res = await browser.storage.local.get(null);
       if (this._cache !== null) {
-        for ([key, val] of Object.entries(res)) {
+        for (const [key, val] of Object.entries(res)) {
           if (
             key.startsWith("config_") &&
             (typeof val === "string" || typeof val === "number")
@@ -112,15 +111,13 @@ export default class Config {
     })();
 
     this._onChanged = (change, area) => {
-      var key:string, val:any;
-
       if (area !== "local") {
         return;
       }
 
-      for ([key, val] of Object.entries(change)) {
+      for (const [key, val] of Object.entries(change)) {
         if (!key.startsWith("config_")) continue;
-        var {newValue} = val;
+        const {newValue} = <any>val;
 
         if (typeof newValue === "string") {
           this._cache.set(key, newValue);
@@ -135,37 +132,36 @@ export default class Config {
       }
     };
 
-    browser.storage.onChanged.addListener(this._onChanged);
+    browser.storage.onChanged.addListener(<any>this._onChanged);
   }
 
-  get (key:string):string|null {
+  get(key: string): string|null {
     if (this._cache.has(`config_${key}`)) {
       return this._cache.get(`config_${key}`)!;
-    } else if (Config._default.has(key)) {
+    }
+    if (Config._default.has(key)) {
       return Config._default.get(key)!;
     }
     return null;
   }
 
   //設定の連想配列をjson文字列で渡す
-  getAll ():string {
-    var json = {};
-    for(var [key, val] of Config._default) {
+  getAll(): string {
+    const json = {};
+    for(const [key, val] of Config._default) {
       json[`config_${key}`] = val;
     }
-    for(var [key, val] of this._cache) {
+    for(const [key, val] of this._cache) {
       json[key] = val;
     }
     return JSON.stringify(json);
   }
 
-  isOn (key:string):boolean {
+  isOn(key: string): boolean {
     return this.get(key) === "on";
   }
 
-  async set (key:string, val:string): Promise<void> {
-    var tmp = {};
-
+  async set(key: string, val: string) {
     if (
       typeof key !== "string" ||
       !(typeof val === "string" || typeof val === "number")
@@ -175,12 +171,13 @@ export default class Config {
       throw new Error("app.Config::setに不適切な値が渡されました");
     }
 
+    const tmp = {};
     tmp[`config_${key}`] = val;
 
     await browser.storage.local.set(tmp)
   }
 
-  async del (key:string): Promise<void> {
+  async del(key: string) {
     if (typeof key !== "string") {
       log("error", "app.Config::delにstring以外の値が渡されました",
         arguments);
@@ -190,8 +187,8 @@ export default class Config {
     await browser.storage.local.remove(`config_${key}`)
   }
 
-  destroy ():void {
+  destroy() {
     this._cache.clear();
-    browser.storage.onChanged.removeListener(this._onChanged);
+    browser.storage.onChanged.removeListener(<any>this._onChanged);
   }
 }

--- a/src/app/Config.ts
+++ b/src/app/Config.ts
@@ -3,7 +3,7 @@ import message from "./Message";
 import {log} from "./Log";
 
 export default class Config {
-  private static _default = new Map<string, string>([
+  private static readonly _default: ReadonlyMap<string, string> = new Map([
     ["layout", "pane-3"],
     ["theme_id", "default"],
     ["default_scrollbar", "off"],
@@ -87,9 +87,9 @@ export default class Config {
     ["replace_str_txt", ""]
   ]);
 
-  private _cache = new Map<string, string>();
-  ready: Function;
-  _onChanged: Function;
+  private readonly _cache = new Map<string, string>();
+  readonly ready: Function;
+  readonly _onChanged: Function;
 
   constructor() {
     const ready = new Callbacks();

--- a/src/app/Config.ts
+++ b/src/app/Config.ts
@@ -145,16 +145,13 @@ export default class Config {
     return null;
   }
 
-  //設定の連想配列をjson文字列で渡す
-  getAll(): string {
-    const json = {};
+  getAll(): Record<string, string> {
+    const object = {};
     for(const [key, val] of Config._default) {
-      json[`config_${key}`] = val;
+      object[`config_${key}`] = val;
     }
-    for(const [key, val] of this._cache) {
-      json[key] = val;
-    }
-    return JSON.stringify(json);
+    Object.assign(object, this._cache);
+    return object;
   }
 
   isOn(key: string): boolean {

--- a/src/app/Config.ts
+++ b/src/app/Config.ts
@@ -89,7 +89,7 @@ export default class Config {
 
   private readonly _cache = new Map<string, string>();
   readonly ready: Function;
-  readonly _onChanged: Function;
+  private readonly _onChanged: Function;
 
   constructor() {
     const ready = new Callbacks();

--- a/src/app/Defer.ts
+++ b/src/app/Defer.ts
@@ -1,22 +1,22 @@
-export function defer (): Promise<void> {
+export function defer() {
   return new Promise( (resolve) => {
     setTimeout(resolve, 100);
   });
 }
 
-export function wait (ms: number): Promise<void> {
+export function wait(ms: number) {
   return new Promise( (resolve) => {
     setTimeout(resolve, ms);
   });
 }
 
-export function wait5s (): Promise<void> {
+export function wait5s() {
   return new Promise( (resolve) => {
     setTimeout(resolve, 5 * 1000);
   });
 }
 
-export function waitAF (): Promise<void> {
+export function waitAF() {
   return new Promise( (resolve) => {
     requestAnimationFrame(<any>resolve);
   });

--- a/src/app/Log.ts
+++ b/src/app/Log.ts
@@ -1,7 +1,7 @@
 import {deepCopy} from "./Util";
 
 type logLevel = "log" | "debug" | "info" | "warn" | "error";
-const logLevels = new Set(<logLevel[]>["log", "debug", "info", "warn", "error"]);
+const logLevels: ReadonlySet<logLevel> = new Set(<logLevel[]>["log", "debug", "info", "warn", "error"]);
 
 export async function criticalError(message: string) {
   new Notification(

--- a/src/app/Log.ts
+++ b/src/app/Log.ts
@@ -1,28 +1,32 @@
 import {deepCopy} from "./Util";
 
 type logLevel = "log" | "debug" | "info" | "warn" | "error";
-var logLevels = <Set<logLevel>>new Set(["log", "debug", "info", "warn", "error"]);
+const logLevels = new Set(<logLevel[]>["log", "debug", "info", "warn", "error"]);
 
-export async function criticalError (message:string):Promise<void> {
+export async function criticalError(message: string) {
   new Notification(
     "深刻なエラーが発生したのでread.crxを終了します",
     { body: `詳細 : ${message}` }
   );
 
-  var {id} = await (<any>parent).browser.tabs.getCurrent();
+  const {id} = await (<any>parent).browser.tabs.getCurrent();
   (<any>parent).browser.tabs.remove(id);
 }
 
-export function log (level:logLevel, ...data:any[]) {
-  if (logLevels.has(level)) {
-    console[level](...data);
-  } else {
+export function log(level: logLevel, ...data: any[]) {
+  if (!logLevels.has(level)) {
     log("error", "app.log: 引数levelが不正な値です", level);
+    return;
   }
+
+  console[level](...data);
 }
 
-export function assertArg (name:string, rules:[any, string, boolean|undefined][]):boolean {
-  for (let [val, type, canbeNull] of rules) {
+// [Val, Type, isNullable]
+type Assertion = [any, string, boolean|undefined]
+
+export function assertArg(name: string, rules: Assertion[]): boolean {
+  for (const [val, type, canbeNull] of rules) {
     if (
       !(canbeNull && (val === null || val === void 0)) &&
       typeof val !== type

--- a/src/app/Message.ts
+++ b/src/app/Message.ts
@@ -3,39 +3,39 @@ import {defer} from "./Defer";
 import {deepCopy} from "./Util";
 
 class Message {
-  private _listenerStore:Map<string, Callbacks> = new Map();
-  private _bc:BroadcastChannel;
+  static readonly CHANNEL_NAME = "readcrx";
+  private _listenerStore: Map<string, Callbacks> = new Map();
+  private _bc: BroadcastChannel;
 
-  constructor () {
-    this._bc = new BroadcastChannel("readcrx");
+  constructor() {
+    this._bc = new BroadcastChannel(Message.CHANNEL_NAME);
     this._bc.on("message", ({data: {type, message}}) => {
       this._fire(type, message);
     });
   }
 
-  private async _fire (type:string, message:any):Promise<void> {
-    var message = deepCopy(message);
+  private async _fire(type:string, message: any) {
+    const msg = deepCopy(message);
 
     await defer();
     if (this._listenerStore.has(type)) {
-      this._listenerStore.get(type)!.call(message);
+      this._listenerStore.get(type)!.call(msg);
     }
   }
 
-  send (type:string, message:any = {}):void {
+  send(type: string, message: any = {}) {
     this._fire(type, message);
     this._bc.postMessage({type, message});
-    return
   }
 
-  on (type:string, listener:Function) {
+  on(type: string, listener: Function) {
     if (!this._listenerStore.has(type)) {
       this._listenerStore.set(type, new Callbacks({persistent: true}));
     }
     this._listenerStore.get(type)!.add(listener);
   }
 
-  off (type:string, listener:Function) {
+  off(type: string, listener: Function) {
     if (this._listenerStore.has(type)) {
       this._listenerStore.get(type)!.remove(listener);
     }

--- a/src/app/Message.ts
+++ b/src/app/Message.ts
@@ -3,7 +3,7 @@ import {defer} from "./Defer";
 import {deepCopy} from "./Util";
 
 class Message {
-  static readonly CHANNEL_NAME = "readcrx";
+  private static readonly CHANNEL_NAME = "readcrx";
   private readonly _listenerStore: Map<string, Callbacks> = new Map();
   private readonly _bc: BroadcastChannel;
 

--- a/src/app/Message.ts
+++ b/src/app/Message.ts
@@ -4,8 +4,8 @@ import {deepCopy} from "./Util";
 
 class Message {
   static readonly CHANNEL_NAME = "readcrx";
-  private _listenerStore: Map<string, Callbacks> = new Map();
-  private _bc: BroadcastChannel;
+  private readonly _listenerStore: Map<string, Callbacks> = new Map();
+  private readonly _bc: BroadcastChannel;
 
   constructor() {
     this._bc = new BroadcastChannel(Message.CHANNEL_NAME);

--- a/src/app/Util.ts
+++ b/src/app/Util.ts
@@ -1,24 +1,22 @@
-export function deepCopy (src:any):any {
-  var copy:any, key:string;
-
+export function deepCopy(src: any): any {
   if (typeof src !== "object" || src === null) {
     return src;
   }
 
-  copy = Array.isArray(src) ? [] : {};
+  const copy = Array.isArray(src) ? [] : {};
 
-  for (key in src) {
+  for (const key in src) {
     copy[key] = deepCopy(src[key]);
   }
 
   return copy;
 }
 
-export function replaceAll (str:string, before:string, after:string): string {
-  var i = str.indexOf(before);
+export function replaceAll(str: string, before: string, after: string): string {
+  let i = str.indexOf(before);
   if (i === -1) return str;
-  var result = str.slice(0, i) + after;
-  var j = str.indexOf(before, i+before.length);
+  let result = str.slice(0, i) + after;
+  let j = str.indexOf(before, i+before.length);
   while (j !== -1) {
     result += str.slice(i+before.length, j) + after;
     i = j;
@@ -27,7 +25,7 @@ export function replaceAll (str:string, before:string, after:string): string {
   return result + str.slice(i+before.length);
 }
 
-export function escapeHtml (str:string):string {
+export function escapeHtml(str: string): string {
   return replaceAll(
     replaceAll(
       replaceAll(
@@ -39,14 +37,12 @@ export function escapeHtml (str:string):string {
   , "'", "&apos;");
 }
 
-export function safeHref (url:string):string {
+export function safeHref(url: string): string {
   return /^https?:\/\//.test(url) ? url : "/view/empty.html";
 }
 
-export function clipboardWrite (str:string):void {
-  var $textarea:HTMLTextAreaElement;
-
-  $textarea = $__("textarea");
+export function clipboardWrite(str: string) {
+  const $textarea = $__("textarea");
   $textarea.value = str;
   document.body.addLast($textarea);
   $textarea.select();

--- a/src/app/Util.ts
+++ b/src/app/Util.ts
@@ -1,4 +1,4 @@
-export function deepCopy(src: any): any {
+export function deepCopy<T>(src: T): T {
   if (typeof src !== "object" || src === null) {
     return src;
   }
@@ -6,10 +6,10 @@ export function deepCopy(src: any): any {
   const copy = Array.isArray(src) ? [] : {};
 
   for (const key in src) {
-    copy[key] = deepCopy(src[key]);
+    copy[<string>key] = deepCopy(src[key]);
   }
 
-  return copy;
+  return <T>copy;
 }
 
 export function replaceAll(str: string, before: string, after: string): string {

--- a/src/core/Bookmark.ts
+++ b/src/core/Bookmark.ts
@@ -8,24 +8,24 @@ export default class Bookmark {
   bel: BrowserBookmarkEntryList;
   promiseFirstScan;
 
-  constructor (rootIdNode: string) {
+  constructor(rootIdNode: string) {
     this.bel = new BrowserBookmarkEntryList(rootIdNode);
     this.promiseFirstScan = new Promise( (resolve, reject) => {
-      this.bel.ready.add(() => {
+      this.bel.ready.add( () => {
         resolve();
 
-        this.bel.onChanged.add(({type: typeName, entry: bookmark}) => {
-          var type = "";
+        this.bel.onChanged.add( ({type: typeName, entry: bookmark}) => {
+          let type = "";
           switch (typeName) {
-            case "ADD": type = "added"; break;
-            case "TITLE": type = "title"; break;
+            case "ADD":       type = "added";     break;
+            case "TITLE":     type = "title";     break;
             case "RES_COUNT": type = "res_count"; break;
-            case "EXPIRED": type = "expired"; break;
-            case "REMOVE": type = "removed"; break;
+            case "EXPIRED":   type = "expired";   break;
+            case "REMOVE":    type = "removed";   break;
           }
           if (type !== "") {
             app.message.send("bookmark_updated", {type, bookmark});
-            return
+            return;
           }
           if (typeName === "READ_STATE") {
             app.message.send("read_state_updated", {
@@ -43,34 +43,34 @@ export default class Bookmark {
     });
   }
 
-  get (url:string):Entry|null {
-    var entry = this.bel.get(url);
+  get(url: string): Entry|null {
+    const entry = this.bel.get(url);
 
     return entry ? entry : null;
   }
 
-  getByBoard (boardURL:string):Entry[] {
+  getByBoard(boardURL: string): Entry[] {
     return this.bel.getThreadsByBoardURL(boardURL);
   }
 
-  getAll ():Entry[] {
+  getAll(): Entry[] {
     return this.bel.getAll();
   }
 
-  getAllThreads ():Entry[] {
+  getAllThreads(): Entry[] {
     return this.bel.getAllThreads();
   }
 
-  getAllBoards ():Entry[] {
+  getAllBoards(): Entry[] {
     return this.bel.getAllBoards();
   }
 
-  async add (url:string, title:string, resCount?:number): Promise<boolean> {
-    var entry = BrowserBookmarkEntryList.URLToEntry(url)!;
+  async add(url: string, title: string, resCount?: number): Promise<boolean> {
+    const entry = BrowserBookmarkEntryList.URLToEntry(url)!;
 
     entry.title = title;
 
-    var readState = await getReadState(entry.url)
+    const readState = await getReadState(entry.url);
     if (readState) {
       entry.readState = readState;
     }
@@ -87,24 +87,24 @@ export default class Bookmark {
     return this.bel.add(entry);
   }
 
-  async remove (url:string):Promise<boolean> {
+  async remove(url: string): Promise<boolean> {
     return this.bel.remove(url);
   }
 
-  async removeAll ():Promise<boolean> {
-    var bookmarkData:Promise<boolean>[] = [];
+  async removeAll(): Promise<boolean> {
+    const bookmarkData: Promise<boolean>[] = [];
 
-    for (var {url} of this.bel.getAll()) {
+    for (const {url} of this.bel.getAll()) {
       bookmarkData.push(this.bel.remove(url));
     }
 
     return (await Promise.all(bookmarkData)).every(v => v);
   }
 
-  async removeAllExpired ():Promise<boolean> {
-    var bookmarkData:Promise<boolean>[] = [];
+  async removeAllExpired(): Promise<boolean> {
+    const bookmarkData: Promise<boolean>[] = [];
 
-    for (var {url, expired} of this.bel.getAll()) {
+    for (const {url, expired} of this.bel.getAll()) {
       if (expired) {
         bookmarkData.push(this.bel.remove(url));
       }
@@ -113,9 +113,9 @@ export default class Bookmark {
     return (await Promise.all(bookmarkData)).every(v => v);
   }
 
-  async updateReadState (readState):Promise<boolean> {
+  async updateReadState(readState): Promise<boolean> {
     // TODO
-    var entry = this.bel.get(readState.url);
+    const entry = this.bel.get(readState.url);
 
     if (entry && app.util.isNewerReadState(entry.readState, readState)) {
       entry.readState = readState;
@@ -124,8 +124,8 @@ export default class Bookmark {
     return true;
   }
 
-  async updateResCount (url:string, resCount:number):Promise<boolean> {
-    var entry = this.bel.get(url);
+  async updateResCount(url:string, resCount:number): Promise<boolean> {
+    const entry = this.bel.get(url);
 
     if (entry && (!entry.resCount || entry.resCount < resCount)) {
       entry.resCount = resCount;
@@ -134,8 +134,8 @@ export default class Bookmark {
     return true;
   }
 
-  async updateExpired (url:string, expired:boolean):Promise<boolean> {
-    var entry = this.bel.get(url);
+  async updateExpired(url:string, expired:boolean): Promise<boolean> {
+    const entry = this.bel.get(url);
 
     if (entry) {
       entry.expired = expired;
@@ -144,9 +144,9 @@ export default class Bookmark {
     return true;
   }
 
-  async import (newEntry:Entry):Promise<boolean> {
-    var entry = this.bel.get(newEntry.url);
-    var updateEntry = false;
+  async import(newEntry: Entry): Promise<boolean> {
+    let entry = this.bel.get(newEntry.url);
+    let updateEntry = false;
 
     if (!entry) {
       await this.add(newEntry.url, newEntry.title);

--- a/src/core/Bookmark.ts
+++ b/src/core/Bookmark.ts
@@ -5,8 +5,8 @@ import {threadToBoard} from "./URL"
 import {get as getReadState} from "./ReadState.coffee"
 
 export default class Bookmark {
-  bel: BrowserBookmarkEntryList;
-  promiseFirstScan;
+  readonly bel: BrowserBookmarkEntryList;
+  readonly promiseFirstScan;
 
   constructor(rootIdNode: string) {
     this.bel = new BrowserBookmarkEntryList(rootIdNode);

--- a/src/core/Bookmark.ts
+++ b/src/core/Bookmark.ts
@@ -98,7 +98,7 @@ export default class Bookmark {
       bookmarkData.push(this.bel.remove(url));
     }
 
-    return Boolean(await Promise.all(bookmarkData));
+    return (await Promise.all(bookmarkData)).every(v => v);
   }
 
   async removeAllExpired ():Promise<boolean> {
@@ -110,7 +110,7 @@ export default class Bookmark {
       }
     }
 
-    return Boolean(await Promise.all(bookmarkData));
+    return (await Promise.all(bookmarkData)).every(v => v);
   }
 
   async updateReadState (readState):Promise<boolean> {

--- a/src/core/BookmarkEntryList.ts
+++ b/src/core/BookmarkEntryList.ts
@@ -28,8 +28,8 @@ export function newerEntry(a:Entry, b:Entry): Entry|null {
 }
 
 export class EntryList {
-  private cache = new Map<string, Entry>();
-  private boardURLIndex = new Map<string, Set<string>>();
+  private readonly cache = new Map<string, Entry>();
+  private readonly boardURLIndex = new Map<string, Set<string>>();
 
   async add(entry: Entry): Promise<boolean> {
     if (this.get(entry.url)) return false;
@@ -151,8 +151,8 @@ export interface BookmarkUpdateEvent {
 }
 
 export class SyncableEntryList extends EntryList {
-  onChanged = new app.Callbacks({persistent: true});
-  private observerForSync: Function;
+  readonly onChanged = new app.Callbacks({persistent: true});
+  private readonly observerForSync: Function;
 
   constructor () {
     super();

--- a/src/core/BookmarkEntryList.ts
+++ b/src/core/BookmarkEntryList.ts
@@ -19,7 +19,7 @@ export interface Entry {
   expired: boolean;
 }
 
-export function newerEntry (a:Entry, b:Entry):Entry|null {
+export function newerEntry(a:Entry, b:Entry): Entry|null {
   if (a.resCount !== null && b.resCount !== null && a.resCount !== b.resCount) {
     return a.resCount > b.resCount ? a : b;
   }
@@ -31,9 +31,7 @@ export class EntryList {
   private cache = new Map<string, Entry>();
   private boardURLIndex = new Map<string, Set<string>>();
 
-  async add (entry:Entry):Promise<boolean> {
-    var boardURL:string;
-
+  async add(entry: Entry): Promise<boolean> {
     if (this.get(entry.url)) return false;
 
     entry = app.deepCopy(entry);
@@ -41,7 +39,7 @@ export class EntryList {
     this.cache.set(entry.url, entry);
 
     if (entry.type === "thread") {
-      boardURL = threadToBoard(entry.url);
+      const boardURL = threadToBoard(entry.url);
       if (!this.boardURLIndex.has(boardURL)) {
         this.boardURLIndex.set(boardURL, new Set());
       }
@@ -50,24 +48,22 @@ export class EntryList {
     return true;
   }
 
-  async update (entry:Entry):Promise<boolean> {
+  async update(entry: Entry): Promise<boolean> {
     if (!this.get(entry.url)) return false;
 
     this.cache.set(entry.url, app.deepCopy(entry));
     return true;
   }
 
-  async remove (url:string):Promise<boolean> {
-    var boardURL:string;
-
+  async remove(url: string): Promise<boolean> {
     url = fixUrl(url);
 
     if (!this.cache.has(url)) return false;
 
     if (this.cache.get(url)!.type === "thread") {
-      boardURL = threadToBoard(url);
+      const boardURL = threadToBoard(url);
       if (this.boardURLIndex.has(boardURL)) {
-        let threadList = this.boardURLIndex.get(boardURL)!;
+        const threadList = this.boardURLIndex.get(boardURL)!;
         if (threadList.has(url)) {
           threadList.delete(url);
         }
@@ -78,11 +74,10 @@ export class EntryList {
     return true;
   }
 
-  import (target:EntryList):void {
-    for(var b of target.getAll()) {
-      var a:Entry;
-
-      if (a = this.get(b.url)) {
+  import(target: EntryList): void {
+    for(const b of target.getAll()) {
+      const a = this.get(b.url);
+      if (a) {
         if (a.type === "thread" && b.type === "thread") {
           if (newerEntry(a, b) === b) {
             this.update(b);
@@ -94,20 +89,19 @@ export class EntryList {
     }
   }
 
-  serverMove (from:string, to:string):void {
-    var entry:Entry, tmp, reg;
-
+  serverMove(from:string, to:string): void {
     // 板ブックマーク移行
-    if (entry = this.get(from)) {
-      this.remove(entry.url);
-      entry.url = to;
-      this.add(entry);
+    const boardEntry = this.get(from)
+    if (boardEntry) {
+      this.remove(boardEntry.url);
+      boardEntry.url = to;
+      this.add(boardEntry);
     }
 
-    reg = /^https?:\/\/[\w\.]+\//
-    tmp = reg.exec(to)[0];
+    const reg = /^https?:\/\/[\w\.]+\//;
+    const tmp = reg.exec(to)![0];
     // スレブックマーク移行
-    for(var entry of this.getThreadsByBoardURL(from)) {
+    for(const entry of this.getThreadsByBoardURL(from)) {
       this.remove(entry.url);
 
       entry.url = entry.url.replace(reg, tmp);
@@ -119,33 +113,30 @@ export class EntryList {
     }
   }
 
-  get (url:string):Entry {
+  get(url: string): Entry {
     url = fixUrl(url);
 
     return this.cache.has(url) ? app.deepCopy(this.cache.get(url)) : null;
   }
 
-  getAll ():Entry[] {
+  getAll(): Entry[] {
     return Array.from(this.cache.values());
   }
 
-  getAllThreads ():Entry[] {
-    var res:Entry[] = Array.from(this.cache.values());
-    return res.filter( ({type}) => type === "thread");
+  getAllThreads(): Entry[] {
+    return this.getAll().filter( ({type}) => type === "thread");
   }
 
-  getAllBoards ():Entry[] {
-    var res:Entry[] = Array.from(this.cache.values());
-    return res.filter( ({type}) => type === "board");
+  getAllBoards(): Entry[] {
+    return this.getAll().filter( ({type}) => type === "board");
   }
 
-  getThreadsByBoardURL (url:string):Entry[] {
-    var res:Entry[] = [], threadURL:string;
-
+  getThreadsByBoardURL(url: string): Entry[] {
+    const res: Entry[] = [];
     url = fixUrl(url);
 
     if (this.boardURLIndex.has(url)) {
-      for (threadURL of this.boardURLIndex.get(url)!) {
+      for (const threadURL of this.boardURLIndex.get(url)!) {
         res.push(this.get(threadURL));
       }
     }
@@ -159,19 +150,19 @@ export interface BookmarkUpdateEvent {
   entry: Entry;
 }
 
-export class SyncableEntryList extends EntryList{
+export class SyncableEntryList extends EntryList {
   onChanged = new app.Callbacks({persistent: true});
-  private observerForSync:Function;
+  private observerForSync: Function;
 
   constructor () {
     super();
 
-    this.observerForSync = (e:BookmarkUpdateEvent) => {
+    this.observerForSync = (e: BookmarkUpdateEvent) => {
       this.manipulateByBookmarkUpdateEvent(e);
     };
   }
 
-  async add (entry:Entry):Promise<boolean> {
+  async add(entry: Entry): Promise<boolean> {
     if (!super.add(entry)) return false;
 
     this.onChanged.call({
@@ -181,8 +172,8 @@ export class SyncableEntryList extends EntryList{
     return true;
   }
 
-  async update (entry:Entry):Promise<boolean> {
-    var before = this.get(entry.url);
+  async update(entry: Entry): Promise<boolean> {
+    const before = this.get(entry.url);
 
     if (!super.update(entry)) return false;
 
@@ -227,8 +218,8 @@ export class SyncableEntryList extends EntryList{
     return true;
   }
 
-  async remove (url:string):Promise<boolean> {
-    var entry:Entry = this.get(url);
+  async remove(url: string): Promise<boolean> {
+    const entry = this.get(url);
 
     if (!super.remove(url)) return false;
 
@@ -239,43 +230,41 @@ export class SyncableEntryList extends EntryList{
     return true;
   }
 
-  private manipulateByBookmarkUpdateEvent (e:BookmarkUpdateEvent) {
-    switch (e.type) {
+  private manipulateByBookmarkUpdateEvent({type, entry}: BookmarkUpdateEvent) {
+    switch (type) {
       case "ADD":
-        this.add(e.entry);
+        this.add(entry);
         break;
       case "TITLE":
       case "RES_COUNT":
       case "READ_STATE":
       case "EXPIRED":
-        this.update(e.entry);
+        this.update(entry);
         break;
       case "REMOVE":
-        this.remove(e.entry.url);
+        this.remove(entry.url);
         break;
     }
   }
 
-  private followDeletion (b:EntryList):void {
-    var aList:string[], bList:string[], rmList:string[];
+  private followDeletion(b: EntryList) {
+    const aList = this.getAll().map( ({url}) => url);
+    const bList = b.getAll().map( ({url}) => url);
 
-    aList = this.getAll().map( ({url}) => url);
-    bList = b.getAll().map( ({url}) => url);
+    const rmList = aList.filter( url => !bList.includes(url));
 
-    rmList = aList.filter( url => !bList.includes(url));
-
-    for(var url of rmList) {
+    for(const url of rmList) {
       this.remove(url);
     }
   }
 
-  syncStart (b:SyncableEntryList):void {
+  syncStart(b: SyncableEntryList) {
     b.import(this);
 
     this.syncResume(b);
   }
 
-  syncResume (b:SyncableEntryList):void {
+  syncResume(b: SyncableEntryList) {
     this.import(b);
     this.followDeletion(b);
 
@@ -283,7 +272,7 @@ export class SyncableEntryList extends EntryList{
     b.onChanged.add(this.observerForSync);
   }
 
-  syncStop (b:SyncableEntryList):void {
+  syncStop(b: SyncableEntryList) {
     this.onChanged.remove(b.observerForSync);
     b.onChanged.remove(this.observerForSync);
   }

--- a/src/core/BookmarkEntryList.ts
+++ b/src/core/BookmarkEntryList.ts
@@ -248,13 +248,13 @@ export class SyncableEntryList extends EntryList {
   }
 
   private followDeletion(b: EntryList) {
-    const aList = this.getAll().map( ({url}) => url);
-    const bList = b.getAll().map( ({url}) => url);
+    const aEntries = this.getAll();
+    const bList = new Set(b.getAll().map( ({url}) => url));
 
-    const rmList = aList.filter( url => !bList.includes(url));
-
-    for(const url of rmList) {
-      this.remove(url);
+    for (const {url} of aEntries) {
+      if (!bList.has(url)) {
+        this.remove(url);
+      }
     }
   }
 

--- a/src/core/BrowserBookmarkEntryList.ts
+++ b/src/core/BrowserBookmarkEntryList.ts
@@ -3,9 +3,9 @@ import {fix as fixUrl, buildQuery, guessType, parseHashQuery} from "./URL"
 
 export default class BrowserBookmarkEntryList extends SyncableEntryList {
   rootNodeId: string;
-  nodeIdStore = new Map<string, string>();
-  ready = new app.Callbacks();
-  needReconfigureRootNodeId = new app.Callbacks({persistent: true});
+  readonly nodeIdStore = new Map<string, string>();
+  readonly ready = new app.Callbacks();
+  readonly needReconfigureRootNodeId = new app.Callbacks({persistent: true});
 
   static entryToURL(entry: Entry): string {
     const url = fixUrl(entry.url);

--- a/src/core/BrowserBookmarkEntryList.ts
+++ b/src/core/BrowserBookmarkEntryList.ts
@@ -2,8 +2,8 @@ import {Entry, SyncableEntryList, newerEntry} from "./BookmarkEntryList"
 import {fix as fixUrl, buildQuery, guessType, parseHashQuery} from "./URL"
 
 export default class BrowserBookmarkEntryList extends SyncableEntryList {
-  rootNodeId: string;
-  readonly nodeIdStore = new Map<string, string>();
+  private rootNodeId: string;
+  private readonly nodeIdStore = new Map<string, string>();
   readonly ready = new app.Callbacks();
   readonly needReconfigureRootNodeId = new app.Callbacks({persistent: true});
 

--- a/src/core/HTTP.ts
+++ b/src/core/HTTP.ts
@@ -1,12 +1,12 @@
 type headerList = Record<string, string>
 
 export class Request {
-  method: string;
-  url: string;
-  mimeType: string|null;
-  timeout: number;
-  headers: headerList;
-  preventCache: boolean;
+  readonly method: string;
+  readonly url: string;
+  readonly mimeType: string|null;
+  readonly timeout: number;
+  readonly headers: headerList;
+  readonly preventCache: boolean;
   private xhr: XMLHttpRequest;
 
   constructor(

--- a/src/core/HTTP.ts
+++ b/src/core/HTTP.ts
@@ -1,4 +1,4 @@
-type headerList = {[index:string]: string;}
+type headerList = Record<string, string>
 
 export class Request {
   method: string;
@@ -9,7 +9,7 @@ export class Request {
   preventCache: boolean;
   private xhr: XMLHttpRequest;
 
-  constructor (
+  constructor(
     method: string,
     url: string,
     {
@@ -33,10 +33,8 @@ export class Request {
     this.preventCache = preventCache;
   }
 
-  send ():Promise<Response> {
-    var xhr:XMLHttpRequest, url:string, key:string, val:string;
-
-    url = this.url;
+  send(): Promise<Response> {
+    const url = this.url;
 
     if (this.preventCache) {
       this.headers["Pragma"] = "no-cache";
@@ -44,7 +42,7 @@ export class Request {
     }
 
     return new Promise( (resolve, reject) => {
-      xhr = new XMLHttpRequest();
+      const xhr = new XMLHttpRequest();
 
       xhr.open(this.method, url);
 
@@ -54,14 +52,12 @@ export class Request {
 
       xhr.timeout = this.timeout;
 
-      for ([key, val] of Object.entries(this.headers)) {
+      for (const [key, val] of Object.entries(this.headers)) {
         xhr.setRequestHeader(key, val);
       }
 
       xhr.on("loadend", () => {
-        var resonseHeaders;
-
-        resonseHeaders = Request.parseHTTPHeader(xhr.getAllResponseHeaders());
+        const resonseHeaders = Request.parseHTTPHeader(xhr.getAllResponseHeaders());
 
         resolve(new Response(xhr.status, resonseHeaders, xhr.responseText, xhr.responseURL));
       });
@@ -81,16 +77,15 @@ export class Request {
     });
   }
 
-  abort ():void {
+  abort(): void {
     this.xhr.abort();
   }
 
-  static parseHTTPHeader (str: string):headerList {
-    var reg, res, headers, last;
-
-    reg = /^(?:([a-z\-]+):\s*|([ \t]+))(.+)\s*$/gim;
-    headers = {};
-    last = null;
+  static parseHTTPHeader(str: string): headerList {
+    const reg = /^(?:([a-z\-]+):\s*|([ \t]+))(.+)\s*$/gim;
+    const headers: headerList = {};
+    let last: string|undefined;
+    let res: RegExpExecArray|null;
 
     while (res = reg.exec(str)) {
       if (typeof res[1] !== "undefined") {
@@ -108,9 +103,9 @@ export class Request {
 
 export class Response {
   constructor (
-    public status:number,
-    public headers:headerList = {},
-    public body:string,
+    public status: number,
+    public headers: headerList = {},
+    public body: string,
     public responseURL: string
   ) {
   }

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -205,7 +205,7 @@ export async function expandShortURL(shortUrl: string): Promise<string> {
 
       let {status, responseURL: resUrl} = await req.send();
 
-      if (status >= 400) {
+      if (shortUrl === resUrl && status >= 400) {
         return {data: null, url: null};
       }
       // 無限ループの防止

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -13,7 +13,7 @@ export const SHITARABA_ARCHIVE_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitar
 export const MACHI_BOARD_REG = /^(https?):\/\/(?:\w+\.)?machi\.to\/(\w+\/)(?:#.*)?$/;
 export const SHITARABA_BOARD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+\/)(?:#.*)?$/;
 export const CH_BOARD_REG = /^(https?:\/\/[\w\.]+\/(?:subback\/|test\/-\/)?\w+\/)(?:#.*)?$/;
-export function fix (url:string):string {
+export function fix(url: string): string {
   return (
     url
       //2ch.net->5ch.net
@@ -36,7 +36,7 @@ export interface GuessResult {
   type: string;
   bbsType: string;
 }
-export function guessType (url:string):GuessResult {
+export function guessType(url: string): GuessResult {
   url = fix(url);
 
   if (/^https?:\/\/jbbs\.shitaraba\.net\/bbs\/read(?:_archive)?\.cgi\/\w+\/\d+\/\d+\/$/.test(url)) {
@@ -68,42 +68,34 @@ export function guessType (url:string):GuessResult {
 }
 
 export const TSLD_REG = /^https?:\/\/(?:\w+\.)*(\w+\.\w+)\//;
-export function tsld (url:string):string {
-  var res:RegExpExecArray|null;
-
-  res = TSLD_REG.exec(url);
+export function tsld(url: string): string {
+  const res = TSLD_REG.exec(url);
   return res ? res[1] : "";
 }
 
-export function getDomain (urlstr: string):string {
-  var start = urlstr.indexOf("://")+3;
+export function getDomain(urlstr: string): string {
+  const start = urlstr.indexOf("://")+3;
   return urlstr.slice(start, urlstr.indexOf("/", start));
 }
 
-export function getScheme (urlstr: string): string {
+export function getScheme(urlstr: string): string {
   return urlstr.slice(0, urlstr.indexOf("://"));
 }
 
-export function setScheme (urlstr: string, protocol: string): string {
-  var split;
-
-  split = urlstr.indexOf("://");
+export function setScheme(urlstr: string, protocol: string): string {
+  const split = urlstr.indexOf("://");
   return protocol + "://" + urlstr.slice(split+3);
 }
 
-export function changeScheme (urlstr: string): string {
-  var split, protocol;
-
-  split = urlstr.indexOf("://")
-  protocol = (urlstr.slice(0, split) == "http") ? "https" : "http";
+export function changeScheme(urlstr: string): string {
+  const split = urlstr.indexOf("://")
+  const protocol = (urlstr.slice(0, split) == "http") ? "https" : "http";
 
   return protocol + "://" + urlstr.slice(split+3);
 }
 
-export function getResNumber (urlstr: string): string|null {
-  var tmp: string[]|null;
-
-  tmp = /^https?:\/\/[\w\.]+\/(?:\w+\/)?test\/(?:read\.cgi|-)\/\w+\/\d+\/(?:i|g\?g=)?(\d+).*$/.exec(urlstr);
+export function getResNumber(urlstr: string): string|null {
+  let tmp = /^https?:\/\/[\w\.]+\/(?:\w+\/)?test\/(?:read\.cgi|-)\/\w+\/\d+\/(?:i|g\?g=)?(\d+).*$/.exec(urlstr);
   if (tmp !== null) {
     return tmp[1];
   }
@@ -123,7 +115,7 @@ export function getResNumber (urlstr: string): string|null {
   return null;
 }
 
-export function threadToBoard (url:string):string {
+export function threadToBoard(url: string): string {
   return (
     fix(url)
       .replace(/^(https?):\/\/([\w\.]+)\/(?:test|bbs)\/read\.cgi\/(\w+)\/\d+\/$/, "$1://$2/$3/")
@@ -131,22 +123,19 @@ export function threadToBoard (url:string):string {
   );
 }
 
-export function parseQuery (urlStr:string, fromSearch:boolean = true):URLSearchParams {
+export function parseQuery(urlStr: string, fromSearch: boolean = true): URLSearchParams {
   if (fromSearch) {
     return new URLSearchParams(urlStr.slice(1));
   }
   return (new window.URL(urlStr)).searchParams;
 }
 
-export function parseHashQuery (url:string):URLSearchParams {
-  var tmp;
-
-  tmp = /#(.+)$/.exec(url);
-
+export function parseHashQuery(url: string): URLSearchParams {
+  const tmp = /#(.+)$/.exec(url);
   return tmp ? new URLSearchParams(tmp[1]) : new URLSearchParams();
 }
 
-export function buildQuery (data:Record<string, string>) {
+export function buildQuery(data: Record<string, string>): string {
   return (new URLSearchParams(data)).toString();
 }
 
@@ -201,19 +190,19 @@ export const SHORT_URL_LIST = new Set([
   "y2u.be"
 ]);
 
-export async function expandShortURL (shortUrl: string): Promise<string> {
-  var res, finalUrl = "";
-  var cache = new Cache(shortUrl);
+export async function expandShortURL(shortUrl: string): Promise<string> {
+  let finalUrl = "";
+  const cache = new Cache(shortUrl);
 
-  res = await ( async () => {
+  const res = await ( async () => {
     try {
       await cache.get();
       return {data: cache.data, url: null};
     } catch {
-      var req = new Request("HEAD", shortUrl);
+      const req = new Request("HEAD", shortUrl);
       req.timeout = parseInt(app.config.get("expand_short_url_timeout")!);
 
-      var {status, responseURL: resUrl} = await req.send();
+      let {status, responseURL: resUrl} = await req.send();
 
       if (status >= 400) {
         return {data: null, url: null};
@@ -227,10 +216,8 @@ export async function expandShortURL (shortUrl: string): Promise<string> {
       if (SHORT_URL_LIST.has(getDomain(resUrl))) {
         resUrl = await expandShortURL(resUrl)
         return {data: null, url: resUrl};
-      // 短縮URL以外なら終了
-      } else {
-        return {data: null, url: resUrl};
       }
+      return {data: null, url: resUrl};
     }
   })();
 
@@ -248,7 +235,7 @@ export async function expandShortURL (shortUrl: string): Promise<string> {
 const AUDIO_REG = /\.(?:mp3|m4a|wav|oga|spx)(?:[\?#:&].*)?$/;
 const VIDEO_REG = /\.(?:mp4|m4v|webm|ogv)(?:[\?#:&].*)?$/;
 const OGG_REG = /\.(?:ogg|ogx)(?:[\?#:&].*)?$/;
-export function getExtType (filename: string, {
+export function getExtType(filename: string, {
     audio = true,
     video = true,
     oggIsAudio = false,
@@ -275,21 +262,19 @@ export function getExtType (filename: string, {
   return null;
 }
 
-export function convertUrlFromPhone (url: string): string {
-  var regs: RegExp[];
-  var tmp: string[]|null = [];
-  var mode: string;
-  var scheme: string = "";
-  var server: string|null = null;
-  var board: string|null = null;
-  var thread: string|null = null;
-  var resUrl: string = url;
+export function convertUrlFromPhone(url: string): string {
+  let regs: RegExp[];
+  let tmp: string[]|null = [];
+  let scheme = "";
+  let server: string|null = null;
+  let board: string|null = null;
+  let thread: string|null = null;
 
-  function checkReg (value: any, index: number, array: any[]): boolean {
+  const checkReg = (value: any): boolean => {
     return (tmp = value.exec(url));
   }
 
-  mode = tsld(url);
+  let mode = tsld(url);
   switch (mode) {
     case "2ch.net":
     case "5ch.net":
@@ -298,7 +283,7 @@ export function convertUrlFromPhone (url: string): string {
         /(https?):\/\/itest\.5ch\.net\/(?:subback\/)?(\w+)(?:\/)?/,
         /(https?):\/\/c\.2ch\.net\/test\/-\/(\w+)\/(\d+)\//,
         /(https?):\/\/c\.2ch\.net\/test\/-\/(\w+)\//
-      ]
+      ];
       if (regs.some(checkReg)) {
         scheme = tmp[1];
         board = tmp[2];
@@ -319,7 +304,7 @@ export function convertUrlFromPhone (url: string): string {
       regs = [
         /(https?):\/\/sp\.2ch\.sc\/(?:\w+\/)?test\/read\.cgi\/(\w+)\/(\d+)\//,
         /(https?):\/\/sp\.2ch\.sc\/(?:subback\/)?(\w+)\//
-      ]
+      ];
       if (regs.some(checkReg)) {
         scheme = tmp[1];
         board = tmp[2];
@@ -334,7 +319,7 @@ export function convertUrlFromPhone (url: string): string {
       regs = [
         /(https?):\/\/itest\.bbspink\.com\/(?:\w+\/)?test\/read\.cgi\/(\w+)\/(\d+)\//,
         /(https?):\/\/itest\.bbspink\.com\/(?:subback\/)?(\w+)(?:\/)?/
-      ]
+      ];
       if (regs.some(checkReg)) {
         scheme = tmp[1];
         board = tmp[2];
@@ -346,20 +331,18 @@ export function convertUrlFromPhone (url: string): string {
       break;
   }
 
-  if (server !== null) {
-    if (thread !== null) {
-      resUrl = `${scheme}://${server}.${mode}/test/read.cgi/${board}/${thread}/`;
-    } else {
-      resUrl = `${scheme}://${server}.${mode}/${board}/`;
-    }
+  if (server === null) {
+    return url;
   }
-
-  return resUrl;
+  if (thread === null) {
+    return `${scheme}://${server}.${mode}/${board}/`;
+  }
+  return `${scheme}://${server}.${mode}/test/read.cgi/${board}/${thread}/`;
 }
 
-var serverNet = new Map<string, string>();
-var serverSc = new Map<string, string>();
-var serverPink = new Map<string, string>();
+let serverNet = new Map<string, string>();
+let serverSc = new Map<string, string>();
+let serverPink = new Map<string, string>();
 
 interface ResInfo {
   net: boolean;
@@ -367,12 +350,11 @@ interface ResInfo {
   bbspink: boolean;
 }
 
-function applyServerInfo (menu: any[]):ResInfo {
-  var boardNet = new Map<string, string>(),
-    boardSc = new Map<string, string>(),
-    boardPink = new Map<string, string>(),
-    tmp: string[]|null;
-  var res: ResInfo = {
+function applyServerInfo(menu: any[]): ResInfo {
+  const boardNet = new Map<string, string>();
+  const boardSc = new Map<string, string>();
+  const boardPink = new Map<string, string>();
+  const res: ResInfo = {
     net: (serverNet.size > 0),
     sc: (serverSc.size > 0),
     bbspink: (serverPink.size > 0)
@@ -380,13 +362,15 @@ function applyServerInfo (menu: any[]):ResInfo {
 
   if (res.net && res.sc && res.bbspink) return res;
 
-  for (let category of menu) {
-    for (let board of category.board) {
+  for (const category of menu) {
+    for (const board of category.board) {
+      let tmp: string[]|null;
+
       if (!res.net && (tmp = /https?:\/\/(\w+)\.[25]ch\.net\/(\w+)\/.*?/.exec(board.url)) !== null) {
         boardNet.set(tmp[2], tmp[1]);
-      }else if (!res.sc && (tmp = /https?:\/\/(\w+)\.2ch\.sc\/(\w+)\/.*?/.exec(board.url)) !== null) {
+      } else if (!res.sc && (tmp = /https?:\/\/(\w+)\.2ch\.sc\/(\w+)\/.*?/.exec(board.url)) !== null) {
         boardSc.set(tmp[2], tmp[1]);
-      }else if (!res.bbspink && (tmp = /https?:\/\/(\w+)\.bbspink\.com\/(\w+)\/.*?/.exec(board.url)) !== null) {
+      } else if (!res.bbspink && (tmp = /https?:\/\/(\w+)\.bbspink\.com\/(\w+)\/.*?/.exec(board.url)) !== null) {
         boardPink.set(tmp[2], tmp[1]);
       }
     }
@@ -396,44 +380,37 @@ function applyServerInfo (menu: any[]):ResInfo {
   if (boardSc.size > 0) serverSc = boardSc;
   if (boardPink.size > 0) serverPink = boardPink;
 
-  res = {
+  return {
     net: (serverNet.size > 0),
     sc: (serverSc.size > 0),
     bbspink: (serverPink.size > 0)
   };
-
-  return res;
 }
 
-export async function pushServerInfo (menu: any[][]): Promise<void> {
-  var res: ResInfo;
-
-  res = applyServerInfo(menu);
+export async function pushServerInfo(menu: any[][]) {
+  const res = applyServerInfo(menu);
 
   if (res.net && res.sc && res.bbspink) {
     return;
   }
 
-  var tmpUrl: string, tmpMenu: any[][];
   if (!res.net || !res.bbspink) {
-    tmpUrl = `https://menu.5ch.net/bbsmenu.html`;
-    tmpMenu = <any[][]>(await fetchBBSMenu(tmpUrl, false)).menu
-    res = applyServerInfo(tmpMenu);
+    const tmpUrl = `https://menu.5ch.net/bbsmenu.html`;
+    const tmpMenu = <any[][]>(await fetchBBSMenu(tmpUrl, false)).menu
+    applyServerInfo(tmpMenu);
   }
   if (!res.sc) {
-    tmpUrl = `https://menu.2ch.sc/bbsmenu.html`;
-    tmpMenu = <any[][]>(await fetchBBSMenu(tmpUrl, false)).menu
-    res = applyServerInfo(tmpMenu);
+    const tmpUrl = `https://menu.2ch.sc/bbsmenu.html`;
+    const tmpMenu = <any[][]>(await fetchBBSMenu(tmpUrl, false)).menu
+    applyServerInfo(tmpMenu);
   }
 }
 
-function exchangeNetSc (url: string): string|null {
-  var mode: string[]|null;
-  var server: string|null = null;
-  var target: string|null = null;
-  var resUrl: string|null = null;
+function exchangeNetSc(url: string): string|null {
+  let server: string|null = null;
+  let target: string|null = null;
 
-  mode = /(https?):\/\/(\w+)\.(5ch\.net|2ch\.sc)\/test\/read\.cgi\/(\w+)\/(\d+)\//.exec(url);
+  const mode = /(https?):\/\/(\w+)\.(5ch\.net|2ch\.sc)\/test\/read\.cgi\/(\w+)\/(\d+)\//.exec(url);
   if (mode === null) {
     return null;
   }
@@ -450,40 +427,38 @@ function exchangeNetSc (url: string): string|null {
     }
   }
 
-  if (server !== null) {
-    resUrl = `${mode[1]}://${server}.${target}/test/read.cgi/${mode[4]}/${mode[5]}/`;
+  if (server === null) {
+    return null;
   }
-  return resUrl;
+  return `${mode[1]}://${server}.${target}/test/read.cgi/${mode[4]}/${mode[5]}/`;
 }
 
-export async function convertNetSc (url: string): Promise<string> {
-  var newUrl = exchangeNetSc(url);
+export async function convertNetSc(url: string): Promise<string> {
+  const newUrl = exchangeNetSc(url);
 
   if (newUrl) {
     return newUrl;
   }
-  var scheme: string;
-  var tmpUrl: string;
-  var tmp: string[]|null;
 
-  tmp = /(https?):\/\/(\w+)\.5ch\.net\/test\/read\.cgi\/(\w+\/\d+\/)/.exec(url);
+  const tmp = /(https?):\/\/(\w+)\.5ch\.net\/test\/read\.cgi\/(\w+\/\d+\/)/.exec(url);
   if (tmp === null) {
     throw new Error("不明なURL形式です");
   }
-  tmpUrl = `http://${tmp[2]}.2ch.sc/test/read.cgi/${tmp[3]}`;
-  scheme = tmp[1];
+  const tmpUrl = `http://${tmp[2]}.2ch.sc/test/read.cgi/${tmp[3]}`;
+  const scheme = tmp[1];
 
-  var req = new Request("HEAD", tmpUrl);
-  var {status, responseURL: resUrl} = await req.send();
+  const req = new Request("HEAD", tmpUrl);
+  const {status, responseURL: resUrl} = await req.send();
   if (status >= 400) {
     throw new Error("移動先情報の取得の通信に失敗しました");
   }
-  tmp = /https?:\/\/(\w+)\.2ch\.sc\/test\/read\.cgi\/(\w+)\/(\d+)\//.exec(resUrl);
-  if (tmp !== null) {
-    if (serverSc.has(tmp[2]) === false) {
-      serverSc.set(tmp[2], tmp[1]);
-    }
-    resUrl = `${scheme}://${tmp[1]}.2ch.sc/test/read.cgi/${tmp[2]}/${tmp[3]}/`;
+  const tmp2 = /https?:\/\/(\w+)\.2ch\.sc\/test\/read\.cgi\/(\w+)\/(\d+)\//.exec(resUrl);
+  if (tmp2 === null) {
+    return resUrl;
   }
-  return resUrl;
+
+  if (serverSc.has(tmp2[2]) === false) {
+    serverSc.set(tmp2[2], tmp2[1]);
+  }
+  return `${scheme}://${tmp2[1]}.2ch.sc/test/read.cgi/${tmp2[2]}/${tmp2[3]}/`;
 }

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -139,7 +139,7 @@ export function buildQuery(data: Record<string, string>): string {
   return (new URLSearchParams(data)).toString();
 }
 
-export const SHORT_URL_LIST = new Set([
+export const SHORT_URL_LIST: ReadonlySet<string> = new Set([
   "amba.to",
   "amzn.to",
   "bit.ly",
@@ -199,8 +199,9 @@ export async function expandShortURL(shortUrl: string): Promise<string> {
       await cache.get();
       return {data: cache.data, url: null};
     } catch {
-      const req = new Request("HEAD", shortUrl);
-      req.timeout = parseInt(app.config.get("expand_short_url_timeout")!);
+      const req = new Request("HEAD", shortUrl, {
+        timeout: parseInt(app.config.get("expand_short_url_timeout")!)
+      });
 
       let {status, responseURL: resUrl} = await req.send();
 

--- a/src/core/URL.ts
+++ b/src/core/URL.ts
@@ -4,15 +4,15 @@ import {fetch as fetchBBSMenu} from "./BBSMenu.coffee"
 // @ts-ignore
 import Cache from "./Cache.coffee"
 
-export const CH_THREAD_REG = /^(https?:\/\/[\w\.]+\/(?:\w+\/)?test\/(?:read\.cgi|-)\/\w+\/\d+).*$/;
-export const CH_THREAD_REG2 = /^(https?:\/\/[\w\.]+\/\w+)\/?(?!test)$/;
-export const CH_THREAD_ULA_REG = /^(https?):\/\/ula\.5ch\.net\/2ch\/(\w+)\/([\w\.]+)\/(\d+).*$/;
-export const MACHI_THREAD_REG = /^(https?):\/\/(?:\w+\.)?machi\.to\/bbs\/read\.cgi\/(\w+\/\d+).*$/;
-export const SHITARABA_THREAD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(bbs\/read(?:_archive)?\.cgi\/\w+\/\d+\/\d+).*$/;
-export const SHITARABA_ARCHIVE_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+)\/storage\/(\d+)\.html$/;
-export const MACHI_BOARD_REG = /^(https?):\/\/(?:\w+\.)?machi\.to\/(\w+\/)(?:#.*)?$/;
-export const SHITARABA_BOARD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+\/)(?:#.*)?$/;
-export const CH_BOARD_REG = /^(https?:\/\/[\w\.]+\/(?:subback\/|test\/-\/)?\w+\/)(?:#.*)?$/;
+const CH_THREAD_REG = /^(https?:\/\/[\w\.]+\/(?:\w+\/)?test\/(?:read\.cgi|-)\/\w+\/\d+).*$/;
+const CH_THREAD_REG2 = /^(https?:\/\/[\w\.]+\/\w+)\/?(?!test)$/;
+const CH_THREAD_ULA_REG = /^(https?):\/\/ula\.5ch\.net\/2ch\/(\w+)\/([\w\.]+)\/(\d+).*$/;
+const MACHI_THREAD_REG = /^(https?):\/\/(?:\w+\.)?machi\.to\/bbs\/read\.cgi\/(\w+\/\d+).*$/;
+const SHITARABA_THREAD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(bbs\/read(?:_archive)?\.cgi\/\w+\/\d+\/\d+).*$/;
+const SHITARABA_ARCHIVE_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+)\/storage\/(\d+)\.html$/;
+const MACHI_BOARD_REG = /^(https?):\/\/(?:\w+\.)?machi\.to\/(\w+\/)(?:#.*)?$/;
+const SHITARABA_BOARD_REG = /^(https?):\/\/jbbs\.(?:livedoor\.jp|shitaraba\.net)\/(\w+\/\d+\/)(?:#.*)?$/;
+const CH_BOARD_REG = /^(https?:\/\/[\w\.]+\/(?:subback\/|test\/-\/)?\w+\/)(?:#.*)?$/;
 export function fix(url: string): string {
   return (
     url
@@ -67,7 +67,7 @@ export function guessType(url: string): GuessResult {
   return {type: "unknown", bbsType: "unknown"};
 }
 
-export const TSLD_REG = /^https?:\/\/(?:\w+\.)*(\w+\.\w+)\//;
+const TSLD_REG = /^https?:\/\/(?:\w+\.)*(\w+\.\w+)\//;
 export function tsld(url: string): string {
   const res = TSLD_REG.exec(url);
   return res ? res[1] : "";

--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -1,26 +1,23 @@
 export function levenshteinDistance (
-  a:string,
-  b:string,
-  allowReplace:boolean = true
-):number {
-  var repCost:number, table:Uint16Array[], ac:number, bc:number;
-
-  repCost = allowReplace ? 1 : 2;
-
-  table = [];
+  a: string,
+  b: string,
+  allowReplace: boolean = true
+): number {
+  const repCost = allowReplace ? 1 : 2;
+  const table: Uint16Array[] = [];
 
   table[0] = new Uint16Array(b.length+1);
-  for (bc = 0; bc <= b.length; bc++) {
+  for (let bc = 0; bc <= b.length; bc++) {
     table[0][bc] = bc;
   }
 
-  for (ac = 1; ac <= a.length; ac++) {
+  for (let ac = 1; ac <= a.length; ac++) {
     table[ac] = new Uint16Array(b.length+1);
     table[ac][0] = ac;
   }
 
-  for (ac = 1; ac <= a.length; ac++) {
-    for (bc = 1; bc <= b.length; bc++) {
+  for (let ac = 1; ac <= a.length; ac++) {
+    for (let bc = 1; bc <= b.length; bc++) {
       table[ac][bc] = Math.min(
         table[ac - 1][bc] + 1,
         table[ac][bc - 1] + 1,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,16 +5,16 @@ interface Window {
 }
 
 declare namespace app {
-  var config: any;
-  var Callbacks: any;
-  var log: any;
-  var deepCopy: any;
-  var message: any;
-  var defer: any;
+  const config: any;
+  const Callbacks: any;
+  const log: any;
+  const deepCopy: any;
+  const message: any;
+  const defer: any;
 
-  var bookmark: any;
-  var HTTP: any;
-  var util: any;
+  const bookmark: any;
+  const HTTP: any;
+  const util: any;
 }
 
 declare namespace browser.bookmarks {

--- a/src/shortQuery.d.ts
+++ b/src/shortQuery.d.ts
@@ -16,10 +16,10 @@ declare namespace shortQuery {
   }
 }
 
-declare var shortQuery: shortQuery.Static;
-declare var $$: shortQuery.Static;
-declare var $__: Document.createElement;
-declare var $_F: Document.createDocumentFragment;
+declare const shortQuery: shortQuery.Static;
+declare const $$: shortQuery.Static;
+declare const $__: Document.createElement;
+declare const $_F: Document.createDocumentFragment;
 
 interface HTMLCollection {
   [Symbol.iterator](): IterableIterator<HTMLElement>;

--- a/src/ui/Accordion.ts
+++ b/src/ui/Accordion.ts
@@ -4,17 +4,15 @@ import {slideDown, slideUp} from "./Animate.coffee"
 export default class Accordion {
   $element: HTMLElement;
 
-  constructor ($element: HTMLElement) {
-    var accordion: Accordion, openAccordions;
-
+  constructor($element: HTMLElement) {
     this.$element = $element;
 
-    accordion = this;
+    const accordion: Accordion = this;
 
     this.$element.addClass("accordion");
 
-    openAccordions = this.$element.C("accordion_open");
-    for (var i = openAccordions.length - 1; i >= 0; i--) {
+    const openAccordions = this.$element.C("accordion_open");
+    for (let i = openAccordions.length - 1; i >= 0; i--) {
       openAccordions[i].removeClass("accordion_open");
     }
 
@@ -29,34 +27,32 @@ export default class Accordion {
     });
   }
 
-  update (): void {
-    for (var dom of this.$element.$$("h3 + *")) {
+  update() {
+    for (const dom of this.$element.$$("h3 + *")) {
       dom.addClass("hidden");
     }
     this.setOpen(this.$element.$("h3"));
   }
 
-  setOpen ($header: HTMLElement): void {
+  setOpen($header: HTMLElement) {
     $header.addClass("accordion_open");
     $header.next().removeClass("hidden");
   }
 
-  open ($header: HTMLElement): void {
-    var accordion: Accordion;
-
-    accordion = this;
+  open($header: HTMLElement) {
+    const accordion: Accordion = this;
 
     $header.addClass("accordion_open");
     slideDown($header.next());
 
-    for (var dom of $header.parent().child()) {
+    for (const dom of $header.parent().child()) {
       if (dom !== $header && dom.hasClass("accordion_open")) {
         accordion.close(dom);
       }
     }
   }
 
-  close ($header: HTMLElement): void {
+  close($header: HTMLElement) {
     $header.removeClass("accordion_open");
     slideUp($header.next());
   }

--- a/src/ui/Accordion.ts
+++ b/src/ui/Accordion.ts
@@ -2,7 +2,7 @@
 import {slideDown, slideUp} from "./Animate.coffee"
 
 export default class Accordion {
-  $element: HTMLElement;
+  readonly $element: HTMLElement;
 
   constructor($element: HTMLElement) {
     this.$element = $element;

--- a/src/ui/Accordion.ts
+++ b/src/ui/Accordion.ts
@@ -6,9 +6,6 @@ export default class Accordion {
 
   constructor($element: HTMLElement) {
     this.$element = $element;
-
-    const accordion: Accordion = this;
-
     this.$element.addClass("accordion");
 
     const openAccordions = this.$element.C("accordion_open");
@@ -19,9 +16,9 @@ export default class Accordion {
     this.$element.on("click", ({target}) => {
       if (target.parent() === this.$element && target.tagName === "H3") {
         if (target.hasClass("accordion_open")) {
-          accordion.close(target);
+          this.close(target);
         } else {
-          accordion.open(target);
+          this.open(target);
         }
       }
     });
@@ -40,14 +37,12 @@ export default class Accordion {
   }
 
   open($header: HTMLElement) {
-    const accordion: Accordion = this;
-
     $header.addClass("accordion_open");
     slideDown($header.next());
 
     for (const dom of $header.parent().child()) {
       if (dom !== $header && dom.hasClass("accordion_open")) {
-        accordion.close(dom);
+        this.close(dom);
       }
     }
   }

--- a/src/ui/Accordion.ts
+++ b/src/ui/Accordion.ts
@@ -2,7 +2,7 @@
 import {slideDown, slideUp} from "./Animate.coffee"
 
 export default class Accordion {
-  readonly $element: HTMLElement;
+  protected readonly $element: HTMLElement;
 
   constructor($element: HTMLElement) {
     this.$element = $element;

--- a/src/ui/LazyLoad.ts
+++ b/src/ui/LazyLoad.ts
@@ -4,12 +4,12 @@ import {fadeIn} from "./Animate.coffee"
 type HTMLMediaElement = HTMLImageElement | HTMLAudioElement | HTMLVideoElement;
 
 export default class LazyLoad {
-  container: HTMLElement;
+  readonly container: HTMLElement;
   isManualLoad = false;
-  private observer: IntersectionObserver;
+  private readonly observer: IntersectionObserver;
   private medias: HTMLMediaElement[] = [];
   private pause = false;
-  private noNeedAttrs: string[] = [
+  private readonly noNeedAttrs: ReadonlySet<string> = new Set([
     "data-src",
     "data-type",
     "data-extract",
@@ -19,7 +19,7 @@ export default class LazyLoad {
     "data-cookie-referrer",
     "data-referrer",
     "data-user-agent"
-  ];
+  ]);
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -90,7 +90,7 @@ export default class LazyLoad {
     if (imgFlg && !faviconFlg) {
       const attrs = <Attr[]>Array.from($media.attributes);
       for (const {name, value} of attrs) {
-        if (!this.noNeedAttrs.includes(name)) {
+        if (!this.noNeedAttrs.has(name)) {
           $newImg.setAttr(name, value);
         }
       }

--- a/src/ui/LazyLoad.ts
+++ b/src/ui/LazyLoad.ts
@@ -4,7 +4,7 @@ import {fadeIn} from "./Animate.coffee"
 type HTMLMediaElement = HTMLImageElement | HTMLAudioElement | HTMLVideoElement;
 
 export default class LazyLoad {
-  readonly container: HTMLElement;
+  private readonly container: HTMLElement;
   isManualLoad = false;
   private readonly observer: IntersectionObserver;
   private medias: HTMLMediaElement[] = [];

--- a/src/ui/SearchNextThread.ts
+++ b/src/ui/SearchNextThread.ts
@@ -2,7 +2,7 @@
 import {fadeIn, fadeOut} from "./Animate.coffee"
 
 export default class SearchNextThread {
-  private $element: HTMLElement;
+  private readonly $element: HTMLElement;
 
   constructor($element: HTMLElement) {
     this.$element = $element;

--- a/src/ui/SearchNextThread.ts
+++ b/src/ui/SearchNextThread.ts
@@ -2,9 +2,9 @@
 import {fadeIn, fadeOut} from "./Animate.coffee"
 
 export default class SearchNextThread {
-  private $element:HTMLElement;
+  private $element: HTMLElement;
 
-  constructor ($element:HTMLElement) {
+  constructor($element: HTMLElement) {
     this.$element = $element;
 
     this.$element.C("close")[0].on("click", () => {
@@ -12,26 +12,26 @@ export default class SearchNextThread {
     });
   }
 
-  show ():void {
+  show() {
     fadeIn(this.$element);
   }
 
-  hide ():void {
+  hide() {
     fadeOut(this.$element);
   }
 
-  async search (url:string, title:string, resString: string): Promise<void> {
-    var $ol = this.$element.T("ol")[0];
+  async search(url:string, title:string, resString: string) {
+    const $ol = this.$element.T("ol")[0];
 
     $ol.innerHTML = "";
     this.$element.C("current")[0].textContent = title;
     this.$element.C("status")[0].textContent = "検索中";
 
     try {
-      var res = await app.util.searchNextThread(url, title, resString);
+      const res = await app.util.searchNextThread(url, title, resString);
 
-      for(var thread of res) {
-        var $li = $__("li").addClass("open_in_rcrx");
+      for(const thread of res) {
+        const $li = $__("li").addClass("open_in_rcrx");
         $li.textContent = thread.title;
         $li.dataset.href = thread.url;
         $ol.addLast($li);

--- a/src/ui/SelectableAccordion.ts
+++ b/src/ui/SelectableAccordion.ts
@@ -6,31 +6,28 @@ Accordionと違って汎用性が無い。
 */
 
 export default class SelectableAccordion extends Accordion {
-  constructor ($element: HTMLElement) {
+  constructor($element: HTMLElement) {
     super($element);
 
     this.$element.on("click", () => {
-      var selected = this.$element.C("selected");
+      const selected = this.$element.C("selected");
       if (selected.length > 0) {
         selected[0].removeClass("selected");
       }
     });
   }
 
-  getSelected (): HTMLElement|null {
+  getSelected(): HTMLElement|null {
     return this.$element.$("h3.selected, a.selected") || null;
   }
 
-  select (target: HTMLElement): void {
-    var targetHeader: HTMLElement;
-
+  select(target: HTMLElement) {
     this.clearSelect();
 
     if (target.tagName === "H3") {
       this.close(target);
-    }
-    else if (target.tagName === "A") {
-      targetHeader = <HTMLElement>target.parent().parent().prev();
+    } else if (target.tagName === "A") {
+      const targetHeader = <HTMLElement>target.parent().parent().prev();
       if (!targetHeader.hasClass("accordion_open")) {
         this.open(targetHeader);
       }
@@ -40,39 +37,30 @@ export default class SelectableAccordion extends Accordion {
     target.scrollIntoView(<any>{behavior: "instant", block: "center", inline: "center"});
   }
 
-  clearSelect (): void {
-    var selected: HTMLElement|null;
-
-    selected = this.getSelected();
+  clearSelect() {
+    const selected = this.getSelected();
 
     if (selected) {
       selected.removeClass("selected");
     }
   }
 
-  selectNext (repeat: number = 1): void {
-    var current: HTMLElement|null,
-      prevCurrent: HTMLElement,
-      currentH3: HTMLElement,
-      nextH3: HTMLElement,
-      key: number;
+  selectNext(repeat = 1) {
+    let current = this.getSelected();
 
-    if (current = this.getSelected()) {
-      for (key = 0; key < repeat; key++) {
-        prevCurrent = current;
+    if (current) {
+      for (let key = 0; key < repeat; key++) {
+        const prevCurrent = current;
 
         if (current.tagName === "A" && current.parent().next()) {
           current = <HTMLElement>current.parent().next().first();
-        }
-        else {
+        } else {
+          let currentH3 = current;
           if (current.tagName === "A") {
             currentH3 = <HTMLElement>current.parent().parent().prev();
           }
-          else {
-            currentH3 = current;
-          }
 
-          nextH3 = <HTMLElement>currentH3.next();
+          let nextH3 = <HTMLElement>currentH3.next();
           while (nextH3 && nextH3.tagName !== "H3") {
             nextH3 = <HTMLElement>nextH3.next();
           }
@@ -80,8 +68,7 @@ export default class SelectableAccordion extends Accordion {
           if (nextH3) {
             if (nextH3.hasClass("accordion_open")) {
               current = <HTMLElement>nextH3.next().$("li > a");
-            }
-            else {
+            } else {
               current = nextH3;
             }
           }
@@ -91,8 +78,7 @@ export default class SelectableAccordion extends Accordion {
           break;
         }
       }
-    }
-    else {
+    } else {
       current = this.$element.$(".accordion_open + ul a");
       current = current || this.$element.$("h3");
     }
@@ -102,29 +88,22 @@ export default class SelectableAccordion extends Accordion {
     }
   }
 
-  selectPrev (repeat: number = 1): void {
-    var current: HTMLElement|null,
-      prevCurrent: HTMLElement,
-      currentH3: HTMLElement,
-      prevH3: HTMLElement,
-      key: number;
+  selectPrev (repeat = 1) {
+    let current = this.getSelected();
 
-    if (current = this.getSelected()) {
-      for (key = 0; key < repeat; key++) {
-        prevCurrent = current;
+    if (current) {
+      for (let key = 0; key < repeat; key++) {
+        const prevCurrent = current;
 
         if (current.tagName === "A" && current.parent().prev()) {
           current = <HTMLElement>current.parent().prev().first();
-        }
-        else {
+        } else {
+          let currentH3 = current;
           if (current.tagName === "A") {
             currentH3 = <HTMLElement>current.parent().parent().prev();
           }
-          else {
-            currentH3 = current;
-          }
 
-          prevH3 = <HTMLElement>currentH3.prev();
+          let prevH3 = <HTMLElement>currentH3.prev();
           while (prevH3 && prevH3.tagName !== "H3") {
             prevH3 = <HTMLElement>prevH3.prev();
           }
@@ -132,8 +111,7 @@ export default class SelectableAccordion extends Accordion {
           if (prevH3) {
             if (prevH3.hasClass("accordion_open")) {
               current = <HTMLElement>prevH3.next().$("li:last-child > a");
-            }
-            else {
+            } else {
               current = prevH3;
             }
           }
@@ -143,8 +121,7 @@ export default class SelectableAccordion extends Accordion {
           break;
         }
       }
-    }
-    else {
+    } else {
       current = this.$element.$(".accordion_open + ul a");
       current = current || this.$element.$("h3");
     }

--- a/src/ui/Sortable.ts
+++ b/src/ui/Sortable.ts
@@ -19,6 +19,7 @@ export default class Sortable {
   //ドラッグしているDOMの戻るときの中央座標
   targetCenter: Position|null = null;
 
+  // requestAnimationFrameId
   rAFId: number = 0;
 
   clicks: number = 1;
@@ -39,7 +40,7 @@ export default class Sortable {
     this.overlay.on("mouseout", this.onFinish.bind(this));
   }
 
-  setTarget(target: HTMLElement): void {
+  setTarget(target: HTMLElement) {
     this.target = target;
     this.target.addClass("sortable_dragging");
     this.target.style["will-change"] = "transform";
@@ -49,7 +50,7 @@ export default class Sortable {
     };
   }
 
-  removeTarget(): void {
+  removeTarget() {
     if (!this.target) return;
     this.target.removeClass("sortable_dragging");
     this.target.style.transform = null;
@@ -58,7 +59,7 @@ export default class Sortable {
     this.targetCenter = null;
   }
 
-  changeStart(func: Function): void {
+  changeStart(func: Function) {
     const beforeLeft = this.target!.offsetLeft;
     const beforeTop = this.target!.offsetTop;
     func();
@@ -74,7 +75,7 @@ export default class Sortable {
     };
   }
 
-  onMousedown ({target, button}): void {
+  onMousedown({target, button}) {
     if (target === this.container) return;
     if (button !== 0) return;
     if (
@@ -101,7 +102,7 @@ export default class Sortable {
     this.clicks++;
   }
 
-  onStart (target): void {
+  onStart(target) {
     if (!target) return;
     while (target.parent() !== this.container) {
       target = target.parent();
@@ -110,7 +111,7 @@ export default class Sortable {
     document.body.addLast(this.overlay);
   }
 
-  onMove({ pageX, pageY }): void {
+  onMove({ pageX, pageY }) {
     if (!this.isSorting) {
       this.start = {
         x: pageX,
@@ -131,7 +132,7 @@ export default class Sortable {
     }
   }
 
-  _animate (): void {
+  _animate() {
     let tmp = <HTMLElement>this.container.first();
     let diffX = this.last!.x - this.start!.x;
     let diffY = this.last!.y - this.start!.y;
@@ -177,7 +178,7 @@ export default class Sortable {
   }
   animate: Function = this._animate.bind(this);
 
-  onFinish (): void {
+  onFinish() {
     // removeするとmouseoutも発火するので二重に呼ばれる
     this.isSorting = false;
 
@@ -192,7 +193,7 @@ export default class Sortable {
     }
   }
 
-  onContextMenu (e): void {
+  onContextMenu(e) {
     e.preventDefault();
   }
 }

--- a/src/ui/Sortable.ts
+++ b/src/ui/Sortable.ts
@@ -4,11 +4,11 @@ interface Position {
 }
 
 export default class Sortable {
-  container: HTMLElement;
-  option: {exclude?: string};
-  overlay: HTMLElement;
+  readonly container: HTMLElement;
+  readonly option: {exclude?: string};
+  readonly overlay: HTMLElement;
 
-  isSorting: boolean = false;
+  isSorting = false;
   //ドラッグ開始時の場所
   start: Position|null = null;
   //ドラッグ中の場所
@@ -20,10 +20,10 @@ export default class Sortable {
   targetCenter: Position|null = null;
 
   // requestAnimationFrameId
-  rAFId: number = 0;
+  rAFId = 0;
 
-  clicks: number = 1;
-  clickTimer: number = 0;
+  clicks = 1;
+  clickTimer = 0;
 
   constructor (container: HTMLElement, option: {exclude?: string} = {}) {
     this.container = container;
@@ -176,7 +176,7 @@ export default class Sortable {
 
     this.rAFId = requestAnimationFrame(<any>this.animate);
   }
-  animate: Function = this._animate.bind(this);
+  readonly animate: Function = this._animate.bind(this);
 
   onFinish() {
     // removeするとmouseoutも発火するので二重に呼ばれる

--- a/src/ui/Sortable.ts
+++ b/src/ui/Sortable.ts
@@ -4,26 +4,26 @@ interface Position {
 }
 
 export default class Sortable {
-  readonly container: HTMLElement;
-  readonly option: {exclude?: string};
-  readonly overlay: HTMLElement;
+  private readonly container: HTMLElement;
+  private readonly option: {exclude?: string};
+  private readonly overlay: HTMLElement;
 
-  isSorting = false;
+  private isSorting = false;
   //ドラッグ開始時の場所
-  start: Position|null = null;
+  private start: Position|null = null;
   //ドラッグ中の場所
-  last: Position|null = null;
+  private last: Position|null = null;
 
   //ドラッグしているDOM
-  target: HTMLElement|null = null;
+  private target: HTMLElement|null = null;
   //ドラッグしているDOMの戻るときの中央座標
-  targetCenter: Position|null = null;
+  private targetCenter: Position|null = null;
 
   // requestAnimationFrameId
-  rAFId = 0;
+  private rAFId = 0;
 
-  clicks = 1;
-  clickTimer = 0;
+  private clicks = 1;
+  private clickTimer = 0;
 
   constructor (container: HTMLElement, option: {exclude?: string} = {}) {
     this.container = container;
@@ -40,7 +40,7 @@ export default class Sortable {
     this.overlay.on("mouseout", this.onFinish.bind(this));
   }
 
-  setTarget(target: HTMLElement) {
+  private setTarget(target: HTMLElement) {
     this.target = target;
     this.target.addClass("sortable_dragging");
     this.target.style["will-change"] = "transform";
@@ -50,7 +50,7 @@ export default class Sortable {
     };
   }
 
-  removeTarget() {
+  private removeTarget() {
     if (!this.target) return;
     this.target.removeClass("sortable_dragging");
     this.target.style.transform = null;
@@ -59,7 +59,7 @@ export default class Sortable {
     this.targetCenter = null;
   }
 
-  changeStart(func: Function) {
+  private changeStart(func: Function) {
     const beforeLeft = this.target!.offsetLeft;
     const beforeTop = this.target!.offsetTop;
     func();
@@ -75,7 +75,7 @@ export default class Sortable {
     };
   }
 
-  onMousedown({target, button}) {
+  private onMousedown({target, button}) {
     if (target === this.container) return;
     if (button !== 0) return;
     if (
@@ -102,7 +102,7 @@ export default class Sortable {
     this.clicks++;
   }
 
-  onStart(target) {
+  private onStart(target) {
     if (!target) return;
     while (target.parent() !== this.container) {
       target = target.parent();
@@ -111,7 +111,7 @@ export default class Sortable {
     document.body.addLast(this.overlay);
   }
 
-  onMove({ pageX, pageY }) {
+  private onMove({ pageX, pageY }) {
     if (!this.isSorting) {
       this.start = {
         x: pageX,
@@ -132,7 +132,7 @@ export default class Sortable {
     }
   }
 
-  _animate() {
+  private _animate() {
     let tmp = <HTMLElement>this.container.first();
     let diffX = this.last!.x - this.start!.x;
     let diffY = this.last!.y - this.start!.y;
@@ -176,9 +176,9 @@ export default class Sortable {
 
     this.rAFId = requestAnimationFrame(<any>this.animate);
   }
-  readonly animate: Function = this._animate.bind(this);
+  private readonly animate: Function = this._animate.bind(this);
 
-  onFinish() {
+  private onFinish() {
     // removeするとmouseoutも発火するので二重に呼ばれる
     this.isSorting = false;
 
@@ -193,7 +193,7 @@ export default class Sortable {
     }
   }
 
-  onContextMenu(e) {
+  private onContextMenu(e) {
     e.preventDefault();
   }
 }

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -61,8 +61,6 @@ export default class Tab {
   }
 
   constructor(private $element: Element) {
-    const tab: Tab = this;
-
     const $ele = this.$element.addClass("tab");
     const $ul = $__("ul").addClass("tab_tabbar");
     $ul.on("notchedmousewheel", (e) => {
@@ -70,10 +68,10 @@ export default class Tab {
         e.preventDefault();
 
         const tmp = (e.wheelDelta < 0) ? "prev" : "next";
-        const next = (tab.$element.$("li.tab_selected") || {})[tmp]();
+        const next = (this.$element.$("li.tab_selected") || {})[tmp]();
 
         if (next) {
-          tab.update(next.dataset.tabid!, {selected: true});
+          this.update(next.dataset.tabid!, {selected: true});
         }
       }
     });
@@ -87,14 +85,14 @@ export default class Tab {
       if (e.button === 2) return;
 
       if (e.button === 1 && !target.hasClass("tab_locked")) {
-        tab.remove(target.dataset.tabid!);
+        this.remove(target.dataset.tabid!);
       } else {
-        tab.update(target.dataset.tabid!, {selected: true});
+        this.update(target.dataset.tabid!, {selected: true});
       }
     });
     $ul.on("click", ({target}) => {
       if (target.tagName === "IMG") {
-        tab.remove(target.parent().dataset.tabid);
+        this.remove(target.parent().dataset.tabid);
       }
     });
     new VirtualNotch($ul);
@@ -309,32 +307,31 @@ export default class Tab {
   }
 
   remove(tabId: string): void {
-    const tab: Tab = this;
     const $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
     const tabsrc = $tmptab.dataset.tabsrc;
 
-    for (const [key, {url}] of tab.recentClosed.entries()) {
+    for (const [key, {url}] of this.recentClosed.entries()) {
       if (url === tabsrc) {
-        tab.recentClosed.splice(key, 1);
+        this.recentClosed.splice(key, 1);
       }
     }
 
-    tab.recentClosed.push({
+    this.recentClosed.push({
       tabId: $tmptab.dataset.tabid,
       url: tabsrc,
       title: $tmptab.title,
       locked: $tmptab.hasClass("tab_locked")
     });
 
-    if (tab.recentClosed.length > 50) {
-      const tmp = tab.recentClosed.shift()!;
-      tab.historyStore.delete(tmp.tabId);
+    if (this.recentClosed.length > 50) {
+      const tmp = this.recentClosed.shift()!;
+      this.historyStore.delete(tmp.tabId);
     }
 
     if ($tmptab.hasClass("tab_selected")) {
       const next = $tmptab.next() || $tmptab.prev();
       if (next) {
-        tab.update(next.dataset.tabid, {selected: true});
+        this.update(next.dataset.tabid, {selected: true});
       }
     }
     $tmptab.remove();

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -4,16 +4,16 @@ export default class Tab {
   private static idSeed = 0;
   private static tabA: Tab|null = null;
   private static tabB: Tab|null = null;
-  private recentClosed = [];
+  private recentClosed: any[] = [];
   private historyStore = {};
 
-  private static genId (): string {
+  private static genId(): string {
     return "tabId" + ++Tab.idSeed;
   }
 
-  public static saveTabs (): void {
-    var data: any[] = [];
-    for (var {formatedUrl, title, selected, locked} of this.tabA!.getAll().concat(this.tabB!.getAll())) {
+  public static saveTabs() {
+    const data: any[] = [];
+    for (const {formatedUrl, title, selected, locked} of this.tabA!.getAll().concat(this.tabB!.getAll())) {
       data.push({
         url: formatedUrl,
         title,
@@ -24,25 +24,17 @@ export default class Tab {
     localStorage.tab_state = JSON.stringify(data);
   }
 
-  constructor (private $element: Element) {
-    var tab = this;
+  constructor(private $element: Element) {
+    const tab: Tab = this;
 
-    var $ele = this.$element.addClass("tab");
-    var $ul = $__("ul").addClass("tab_tabbar");
+    const $ele = this.$element.addClass("tab");
+    const $ul = $__("ul").addClass("tab_tabbar");
     $ul.on("notchedmousewheel", (e) => {
       if (app.config.isOn("mousewheel_change_tab")) {
-        var tmp: string, next: HTMLElement;
-
         e.preventDefault();
 
-        if (e.wheelDelta < 0) {
-          tmp = "prev";
-        }
-        else {
-          tmp = "next";
-        }
-
-        next = (tab.$element.$("li.tab_selected") || {})[tmp]();
+        const tmp = (e.wheelDelta < 0) ? "prev" : "next";
+        const next = (tab.$element.$("li.tab_selected") || {})[tmp]();
 
         if (next) {
           tab.update(next.dataset.tabid!, {selected: true});
@@ -54,14 +46,13 @@ export default class Tab {
         e.preventDefault();
         return;
       }
-      var target = e.target.closest("li")
+      const target = e.target.closest("li")
       if (target === null) return;
       if (e.button === 2) return;
 
       if (e.button === 1 && !target.hasClass("tab_locked")) {
         tab.remove(target.dataset.tabid!);
-      }
-      else {
+      } else {
         tab.update(target.dataset.tabid!, {selected: true});
       }
     });
@@ -71,14 +62,11 @@ export default class Tab {
       }
     });
     new VirtualNotch($ul);
-    var $div = $__("div").addClass("tab_container");
+    const $div = $__("div").addClass("tab_container");
     $ele.addLast($ul, $div);
 
     window.on("message", ({ origin, data: message, source }) => {
-      var message, tabId: string, history;
-
       if (origin !== location.origin) return;
-
       if (![
           "requestTabHistory",
           "requestTabBack",
@@ -86,13 +74,12 @@ export default class Tab {
         ].includes(message.type)) {
         return;
       }
-
       if (!this.$element.contains(source.frameElement)) {
         return;
       }
 
-      tabId = source.frameElement.dataset.tabid!;
-      history = this.historyStore[tabId];
+      const tabId = source.frameElement.dataset.tabid!;
+      const history = this.historyStore[tabId];
 
       switch (message.type) {
         case "requestTabHistory":
@@ -141,10 +128,10 @@ export default class Tab {
     });
   }
 
-  getAll (): any {
-    var li: HTMLLIElement, res:Object[] = [];
+  getAll(): any[] {
+    const res: any[] = [];
 
-    for (li of this.$element.$$("li")) {
+    for (const li of this.$element.$$("li")) {
       res.push({
         tabId: li.dataset.tabid!,
         url: li.dataset.tabsrc!,
@@ -158,21 +145,18 @@ export default class Tab {
     return res;
   }
 
-  getSelected (): Object|null {
-    var li: HTMLLIElement;
+  getSelected(): any|null {
+    const li = this.$element.$("li.tab_selected");
 
-    if (li = this.$element.$("li.tab_selected")) {
-      return {
-        tabId: li.dataset.tabid,
-        url: li.dataset.tabsrc,
-        title: li.title,
-        selected: true,
-        locked: li.hasClass("tab_locked")
-      };
-    }
-    else {
-      return null;
-    }
+    if (!li) return null;
+
+    return {
+      tabId: li.dataset.tabid,
+      url: li.dataset.tabsrc,
+      title: li.title,
+      selected: true,
+      locked: li.hasClass("tab_locked")
+    };
   }
 
   add (
@@ -191,11 +175,9 @@ export default class Tab {
       restore: boolean
     }> = {}
   ): string {
-    var tabId: string;
-
     title = title === null ? url : title;
 
-    tabId = Tab.genId();
+    const tabId = Tab.genId();
 
     this.historyStore[tabId] = {
       current: 0,
@@ -207,16 +189,16 @@ export default class Tab {
       selected = true;
     }
 
-    var $li = $__("li");
+    const $li = $__("li");
     $li.dataset.tabid = tabId;
     $li.dataset.tabsrc = url;
-    var $img = $__("img");
+    const $img = $__("img");
     $img.src = "/img/close_16x16.&[IMG_EXT]";
     $img.title = "閉じる";
     $li.addLast($__("span"), $img);
     this.$element.$(".tab_tabbar").addLast($li);
 
-    var $iframe = $__("iframe").addClass("tab_content");
+    const $iframe = $__("iframe").addClass("tab_content");
     $iframe.src = lazy ? "/view/empty.html" : url;
     $iframe.dataset.tabid = tabId;
     this.$element.$(".tab_container").addLast($iframe);
@@ -236,39 +218,38 @@ export default class Tab {
       restore: boolean,
       _internal: boolean
     }>
-  ): Promise<void> {
-    var history, $tmptab, $iframe, tmp;
-
+  ) {
     if (typeof param.url === "string") {
       if (!param._internal) {
-        history = this.historyStore[tabId];
+        const history = this.historyStore[tabId];
         history.stack.splice(history.current + 1);
         history.stack.push({url: param.url, title: param.url});
         history.current++;
       }
 
       this.$element.$(`li[data-tabid="${tabId}"]`).dataset.tabsrc = param.url;
-      $tmptab = this.$element.$(`iframe[data-tabid="${tabId}"]`);
+      const $tmptab = this.$element.$(`iframe[data-tabid="${tabId}"]`);
       $tmptab.emit(new Event("tab_beforeurlupdate", {"bubbles": true}));
       $tmptab.src = param.url;
       $tmptab.emit(new Event("tab_urlupdated", {"bubbles": true}));
     }
 
     if (typeof param.title === "string") {
-      tmp = this.historyStore[tabId];
+      const tmp = this.historyStore[tabId];
       tmp.stack[tmp.current].title = param.title;
 
-      $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
+      const $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
       $tmptab.setAttr("title", param.title);
       $tmptab.T("span")[0].textContent = param.title;
     }
 
     if (param.selected) {
-      var $selected = this.$element.C("tab_selected");
-      for (var i = $selected.length-1; i >= 0; i--) {
+      let $iframe;
+      const $selected = this.$element.C("tab_selected");
+      for (let i = $selected.length-1; i >= 0; i--) {
         $selected[i].removeClass("tab_selected");
       }
-      for (var dom of this.$element.$$(`[data-tabid="${tabId}"]`)) {
+      for (const dom of this.$element.$$(`[data-tabid="${tabId}"]`)) {
         dom.addClass("tab_selected");
         if (dom.hasClass("tab_content")) {
           $iframe = dom;
@@ -280,20 +261,20 @@ export default class Tab {
       // 遅延ロード指定のタブをロードする
       // 連続でlazy指定のタブがaddされた時のために非同期処理
       await app.defer();
-      var selectedTab, iframe: HTMLIFrameElement;
 
-      if (selectedTab = this.getSelected()) {
-        iframe = this.$element.$(`iframe[data-tabid="${selectedTab.tabId}"]`);
+      const selectedTab = this.getSelected();
+      if (selectedTab) {
+        const iframe = this.$element.$(`iframe[data-tabid="${selectedTab.tabId}"]`);
         if (iframe.getAttr("src") !== selectedTab.url) {
           iframe.src = selectedTab.url;
         }
       }
     }
     if (param.locked) {
-      $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
+      const $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
       $tmptab.addClass("tab_locked");
     } else if (!(param.locked === void 0 || param.locked === null)) {
-      $tmptab = this.$element.$(`li[data-tabid="${tabId}"].tab_locked`);
+      const $tmptab = this.$element.$(`li[data-tabid="${tabId}"].tab_locked`);
       if ($tmptab !== null) {
         $tmptab.removeClass("tab_locked");
       }
@@ -304,15 +285,13 @@ export default class Tab {
     }
   }
 
-  remove (tabId: string): void {
-    var tab, $tmptab, $tmptabcon, tabsrc: string, tmp, key, next;
+  remove(tabId: string): void {
+    let key;
+    const tab: Tab = this;
+    const $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
+    const tabsrc = $tmptab.dataset.tabsrc;
 
-    tab = this;
-
-    $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
-    tabsrc = $tmptab.dataset.tabsrc;
-
-    for (tmp of tab.recentClosed) {
+    for (const tmp of tab.recentClosed) {
       if (tmp.url === tabsrc) {
         tab.recentClosed.splice(key, 1);
       }
@@ -326,32 +305,33 @@ export default class Tab {
     });
 
     if (tab.recentClosed.length > 50) {
-      tmp = tab.recentClosed.shift();
+      const tmp = tab.recentClosed.shift();
       delete tab.historyStore[tmp.tabId];
     }
 
     if ($tmptab.hasClass("tab_selected")) {
-      if (next = $tmptab.next() || $tmptab.prev()) {
+      const next = $tmptab.next() || $tmptab.prev();
+      if (next) {
         tab.update(next.dataset.tabid, {selected: true});
       }
     }
     $tmptab.remove();
 
-    $tmptabcon = this.$element.$(`iframe[data-tabid="${tabId}"]`);
+    const $tmptabcon = this.$element.$(`iframe[data-tabid="${tabId}"]`);
     $tmptabcon.emit(new Event("tab_removed", {"bubbles": true}));
     $tmptabcon.remove();
 
     Tab.saveTabs()
   }
 
-  getRecentClosed (): any {
+  getRecentClosed(): any {
     return app.deepCopy(this.recentClosed);
   }
 
-  restoreClosed (tabId: string): string|null {
-    var tab, key;
+  restoreClosed(tabId: string): string|null {
+    let key;
 
-    for (tab of this.recentClosed) {
+    for (const tab of this.recentClosed) {
       if (tab.tabId === tabId) {
         this.recentClosed.splice(key, 1);
         return this.add(tab.url, {title: tab.title});
@@ -361,8 +341,8 @@ export default class Tab {
     return null;
   }
 
-  isLocked (tabId: string): boolean {
-    var tab = this.$element.$(`li[data-tabid="${tabId}"]`);
+  isLocked(tabId: string): boolean {
+    const tab = this.$element.$(`li[data-tabid="${tabId}"]`);
     return (tab !== null && tab.hasClass("tab_locked"));
   }
 }

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -286,13 +286,12 @@ export default class Tab {
   }
 
   remove(tabId: string): void {
-    let key;
     const tab: Tab = this;
     const $tmptab = this.$element.$(`li[data-tabid="${tabId}"]`);
     const tabsrc = $tmptab.dataset.tabsrc;
 
-    for (const tmp of tab.recentClosed) {
-      if (tmp.url === tabsrc) {
+    for (const [key, {url}] of tab.recentClosed.entries()) {
+      if (url === tabsrc) {
         tab.recentClosed.splice(key, 1);
       }
     }
@@ -329,9 +328,7 @@ export default class Tab {
   }
 
   restoreClosed(tabId: string): string|null {
-    let key;
-
-    for (const tab of this.recentClosed) {
+    for (const [key, tab] of this.recentClosed.entries()) {
       if (tab.tabId === tabId) {
         this.recentClosed.splice(key, 1);
         return this.add(tab.url, {title: tab.title});

--- a/src/ui/Tab.ts
+++ b/src/ui/Tab.ts
@@ -40,8 +40,8 @@ export default class Tab {
   private static idSeed = 0;
   private static tabA: Tab|null = null;
   private static tabB: Tab|null = null;
-  private recentClosed: ClosedTabInfo[] = [];
-  private historyStore: Map<string, TabHistory>  = new Map();
+  private readonly recentClosed: ClosedTabInfo[] = [];
+  private readonly historyStore: Map<string, TabHistory>  = new Map();
 
   private static genId(): string {
     return "tabId" + ++Tab.idSeed;

--- a/src/ui/ThreadContent.coffee
+++ b/src/ui/ThreadContent.coffee
@@ -751,9 +751,9 @@ export default class ThreadContent
           .replace(/<img src="([\w]+):\/\/(.*?)"[^>]*>/ig, "$1://$2")
           .replace(/<img src="\/\/(.*?)"[^>]*>/ig, "#{scheme}://$1")
           #Rock54
-          .replace(/(?:<small[^>]*>&#128064;|<i>&#128064;<\/i>)<br>Rock54: (Caution|Warning)\(([^<>()]+)\) ?.*?(?:<\/small>)?/ig, "<div-block class=\"rock54\">&#128064; Rock54: $1($2)</div-block>")
+          .replace(/(?:<small[^>]*>&#128064;|<i>&#128064;<\/i>)<br>Rock54: (Caution|Warning)\(([^<>()]+)\) ?.*?(?:<\/small>)?/ig, "<br><div-block class=\"rock54\">&#128064; Rock54: $1($2)</div-block>")
           #SLIPが変わったという表示
-          .replace(/<hr>VIPQ2_EXTDAT: ([^<>]+): EXT was configured /i, "<div-block class=\"slipchange\">VIPQ2_EXTDAT: $1: EXT configure</div-block>")
+          .replace(/<hr>VIPQ2_EXTDAT: ([^<>]+): EXT was configured /i, "<br><div-block class=\"slipchange\">VIPQ2_EXTDAT: $1: EXT configure</div-block>")
           #タグ除去
           .replace(/<(?!(?:br|hr|\/?div-block[^<>]*|\/?b)>).*?(?:>|$)/ig, "")
           .replace(/<(\/)?div-block([^<>]*)>/g, "<$1div$2>")

--- a/src/ui/VirtualNotch.ts
+++ b/src/ui/VirtualNotch.ts
@@ -6,20 +6,18 @@ export default class VirtualNotch {
   private wheelDelta = 0;
   private lastMouseWheel = Date.now();
 
-  constructor (private element: Element, private threshold: number = 100) {
+  constructor(private element: Element, private threshold = 100) {
     this.element.on("wheel", this.onMouseWheel.bind(this), { passive: true });
     setInterval(this.onInterval.bind(this), 500);
   }
 
-  private onInterval (): void {
+  private onInterval() {
     if (this.lastMouseWheel < Date.now() - 500) {
       this.wheelDelta = 0;
     }
   }
 
-  private onMouseWheel (e: WheelEvent): void {
-    var event: NotchedMouseWheelEvent;
-
+  private onMouseWheel(e: WheelEvent) {
     // @ts-ignore: true === falseは常にfalse
     if ("&[BROWSER]" === "chrome") {
       this.wheelDelta += e.deltaY;
@@ -31,7 +29,7 @@ export default class VirtualNotch {
     this.lastMouseWheel = Date.now();
 
     while (Math.abs(this.wheelDelta) >= this.threshold) {
-      event = <NotchedMouseWheelEvent>new MouseEvent("notchedmousewheel");
+      const event = <NotchedMouseWheelEvent>new MouseEvent("notchedmousewheel");
       event.wheelDelta = this.threshold * (this.wheelDelta > 0 ? 1 : -1);
       this.wheelDelta -= event.wheelDelta;
       this.element.emit(event);

--- a/src/view/config.coffee
+++ b/src/view/config.coffee
@@ -824,9 +824,9 @@ app.boot("/view/config.html", ["Cache", "BBSMenu"], (Cache, BBSMenu) ->
       return
     exportFunc: ->
       content = app.config.getAll()
-        .replace(/"config_last_board_sort_config":".*?","/,"\"")
-        .replace(/"config_last_version":".*?","/,"\"")
-      return content
+      delete content.config_last_board_sort_config
+      delete content.config_last_version
+      return JSON.stringify(content)
   )
 
   # ImageReplaceDatをインポート


### PR DESCRIPTION
 - Fix: .tsの全般的なリファクタリング
    - `var` -> `let`/`const`
    - 関数の戻り値が`void`/`Promise<void>`の場合は省略(それ以外は明記)に統一
    - 関数や`if`/`for`などのブロックのスペースを統一
    - 変数の宣言位置の統一
    - 再代入すべきでないプロパティに`readonly`を付加
    - 外から操作しないプロパティに`private`を付加
    - 不要な`self = this`を除去
 - Fix: リファクタリング
    - `app.getAll()`が文字列ではなくオブジェクトを返すように
    - `UI/Tab.ts`のオブジェクトの型を改善
    - `UI.Tab.historyStore`を`Object`から`Map`に変更
    - `app.deepCopy()`の型を改善
 - Fix: `app.Bookmark.removeAll()`と`removeAllExpired()`が常に`true`を返していたのを修正
 - Fix: タブ履歴の重複エントリが消えていなかったのを修正
 - Fix: 一部の短縮URLの展開に失敗する場合があるのを修正
    - Twitterの短縮URLは展開後のURLに`HEAD`で取得すると`GET`では存在していても`403`が返ってくる
 - Fix: Rock54などが表示されているレスで展開された短縮URLの位置がずれているのを修正
    - `短縮URL -> Rock54表示 -> 短縮URL展開表示`の順になっていた

あけましておめでとうございます。今年もよろしくお願いします。
新年から大きなプルリクですが…