### PR TITLE
Update: manifest v3への対応

### DIFF
--- a/gulp/other.js
+++ b/gulp/other.js
@@ -17,15 +17,26 @@ const manifest = function (browser) {
       tmpManifest.permissions = tmpManifest.permissions.filter(
         (v) => !["webRequest", "webRequestBlocking"].includes(v)
       );
+      delete tmpManifest.background.scripts;
       delete tmpManifest.applications;
     } else if (browser === "firefox") {
+      tmpManifest.manifest_version = 2;
       delete tmpManifest.update_url;
       delete tmpManifest.minimum_chrome_version;
+      tmpManifest.content_security_policy =
+        tmpManifest.content_security_policy.extension_pages;
       delete tmpManifest.incognito;
       tmpManifest.permissions = tmpManifest.permissions.filter(
         (v) => !["declarativeNetRequest"].includes(v)
       );
       delete tmpManifest.declarative_net_request;
+      delete tmpManifest.background.service_worker;
+      tmpManifest.permissions.push(...tmpManifest.host_permissions);
+      delete tmpManifest.host_permissions;
+      tmpManifest.browser_action = tmpManifest.action;
+      delete tmpManifest.action;
+      tmpManifest.web_accessible_resources =
+        tmpManifest.web_accessible_resources[0].resources;
     }
 
     await fs.ensureDir(output);

--- a/src/background.js
+++ b/src/background.js
@@ -12,7 +12,8 @@ const searchRcrx = async function () {
 };
 
 // アイコンクリック時の動作
-browser.browserAction.onClicked.addListener(async function (currentTab) {
+const browserAction = "&[BROWSER]" === "chrome" ? browser.action : browser.browserAction;
+browserAction.onClicked.addListener(async function (currentTab) {
   // 現在のタブが自分自身なら何もしない
   if (isTabReadcrx(currentTab)) {
     return;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,9 +4,11 @@
   "update_url": "https://readcrx-2.github.io/read.crx-2/updates.xml",
   "homepage_url": "https://readcrx-2.github.io/read.crx-2/",
   "description": "2chブラウザ",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "minimum_chrome_version": "103",
-  "content_security_policy": "default-src 'self'; img-src 'self' http: https: data:; style-src 'self' 'unsafe-inline'; connect-src 'self' http: https:; frame-src 'self' http: https: blob:; font-src data:; media-src 'self' http: https:",
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; img-src 'self' http: https: data:; style-src 'self' 'unsafe-inline'; connect-src 'self' http: https:; frame-src 'self' http: https: blob:; font-src data:; media-src 'self' http: https:"
+  },
   "incognito": "split",
   "options_ui": {
     "page": "view/index.html?q=config",
@@ -22,7 +24,9 @@
     "webRequest",
     "webRequestBlocking",
     "declarativeNetRequest",
-    "contextMenus",
+    "contextMenus"
+  ],
+  "host_permissions": [
     "http://*/",
     "https://*/"
   ],
@@ -35,10 +39,11 @@
       }
     ]
   },
-  "background": {
-    "scripts": ["background.js"]
+  "background" : {
+    "scripts": ["background.js"],
+    "service_worker": "background.js"
   },
-  "browser_action": {
+  "action": {
     "default_icon": {
       "16": "img/read.crx_16x16.png",
       "32": "img/read.crx_32x32.png",
@@ -78,23 +83,39 @@
     }
   ],
   "web_accessible_resources": [
-    "/view/index.html",
-    "/view/board.html",
-    "/view/bookmark.html",
-    "/view/bookmark_source_selector.html",
-    "/view/config.html",
-    "/view/empty.html",
-    "/view/history.html",
-    "/view/writehistory.html",
-    "/view/inputurl.html",
-    "/view/search.html",
-    "/view/sidemenu.html",
-    "/view/thread.html"
+    {
+      "resources": [
+        "/view/index.html",
+        "/view/board.html",
+        "/view/bookmark.html",
+        "/view/bookmark_source_selector.html",
+        "/view/config.html",
+        "/view/empty.html",
+        "/view/history.html",
+        "/view/writehistory.html",
+        "/view/inputurl.html",
+        "/view/search.html",
+        "/view/sidemenu.html",
+        "/view/thread.html",
+        "/write/submit_res.html",
+        "/write/submit_thread.html"
+      ],
+      "matches": [
+        "*://*.2ch.net/*",
+        "*://*.5ch.net/*",
+        "*://jbbs.shitaraba.net/*",
+        "*://*.machi.to/*",
+        "*://*.open2ch.net/*",
+        "*://*.2ch.sc/*",
+        "*://*.bbspink.com/*"
+      ],
+      "extension_ids": []
+    }
   ],
   "applications": {
     "gecko": {
       "id": "read.crx2@read.crx",
-      "strict_min_version": "58.0",
+      "strict_min_version": "103",
       "update_url": "https://readcrx-2.github.io/read.crx-2/updates_firefox.json"
     }
   }

--- a/src/write/cs_write.js
+++ b/src/write/cs_write.js
@@ -7,53 +7,35 @@
 
   let submitThreadFlag = false;
 
-  const exec = function (javascript) {
-    const script = document.createElement("script");
-    script.innerHTML = javascript;
-    document.body.appendChild(script);
-  };
-
   const sendMessagePing = function () {
-    exec(`\
-parent.postMessage({type: "ping"}, "${origin}");\
-`);
+    parent.postMessage({type: "ping"}, `${origin}`);
   };
 
   const sendMessageSuccess = function (moveMs) {
     if (submitThreadFlag) {
       const jumpUrl = getJumpUrl();
-      exec(`\
-parent.postMessage({
-  type : "success",
-  key: "${jumpUrl}",
-  message: ${moveMs}
-}, "${origin}");\
-`);
+      parent.postMessage({
+        type : "success",
+        key: `${jumpUrl}`,
+        message: `${moveMs}`
+      }, `${origin}`);
     } else {
-      exec(`\
-parent.postMessage({type: "success", message: ${moveMs}}, "${origin}");\
-`);
+      parent.postMessage({type: "success", message: `${moveMs}`}, `${origin}`);
     }
   };
 
   const sendMessageConfirm = function () {
-    exec(`\
-parent.postMessage({type: "confirm"}, "${origin}");\
-`);
+    parent.postMessage({type: "confirm"}, `${origin}`);
   };
 
   const sendMessageError = function (message) {
     if (typeof message === "string") {
-      exec(`\
-parent.postMessage({
-  type: "error",
-  message: "${message.replace(/\"/g, "&quot;")}"
-}, "${origin}");\
-`);
+      parent.postMessage({
+        type: "error",
+        message: `${message.replace(/\"/g, "&quot;")}`
+      }, `${origin}`);
     } else {
-      exec(`\
-parent.postMessage({type: "error"}, "${origin}");\
-`);
+      parent.postMessage({type: "error"}, `${origin}`);
     }
   };
 


### PR DESCRIPTION
fixed https://github.com/readcrx-2/read.crx-2/issues/545

manifest v3への対応

- ガイド
    - https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/
    - https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/

### TODO

- [x] `webRequestBlocking` => `declarativeNetRequest` への変更に伴う実装の修正とmanifestのルールの追加
    - https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/
    - ざっくりしたルールを定義しておいて、updateSessionRulesで書き換えることになりそう
    - https://github.com/MartinWie/Framer#technical-words 参考になる
- [x] `browser.browserActiion` => `browser.action` の変更に伴う修正
    - https://developer.chrome.com/docs/extensions/reference/browserAction/
    - https://developer.chrome.com/docs/extensions/reference/action/
- [x] 書き込み後の処理が動かない
- [x] read.crxで開くが動作しない