### PR TITLE
Fix/bookmark: app.config.ready を待ってからブックマークを初期化する

### DIFF
--- a/src/view/index.js
+++ b/src/view/index.js
@@ -599,7 +599,7 @@ app.main = function () {
   const $view = document.documentElement;
   new app.view.Index($view);
 
-  (function () {
+  app.config.ready(function () {
     // bookmark_idが未設定の場合、わざと無効な値を渡してneedReconfigureRootNodeId
     // をcallさせる。
     app.bookmark = new app.Bookmark(app.config.get("bookmark_id") || "dummy");
@@ -607,10 +607,10 @@ app.main = function () {
     app.bookmarkEntryList.needReconfigureRootNodeId.add(function () {
       app.message.send("open", { url: "bookmark_source_selector" });
     });
-  })();
 
-  app.bookmarkEntryList.ready.add(function () {
-    $$.I("left_pane").src = "/view/sidemenu.html";
+    app.bookmarkEntryList.ready.add(function () {
+      $$.I("left_pane").src = "/view/sidemenu.html";
+    });
   });
 
   (async function () {


### PR DESCRIPTION
## 概要

`app.main()` 内のブックマーク初期化処理が、`app.config` のロード完了を待たずに即時実行されていたため、起動タイミングによっては `bookmark_id` を読み取れない問題を修正します。

## 問題

ブックマーク初期化は即時実行関数 (IIFE) で実行されていました。

```js
(function () {
  app.bookmark = new app.Bookmark(app.config.get("bookmark_id") || "dummy");
  ...
})();
```

`app.config` のロードが完了する前にこれが走ると、`app.config.get("bookmark_id")` が未設定値を返し、無効値 `"dummy"` にフォールバックします。その結果、正しいルートノードでブックマークが初期化されず、不要な `needReconfigureRootNodeId`（ブックマークソース選択ダイアログ）が呼ばれてしまいます。

## 修正

初期化処理を `app.config.ready()` でラップし、設定のロード完了後に正しい `bookmark_id` を使って初期化するようにしました。

`app.bookmarkEntryList.ready` のハンドラ登録も、`app.bookmarkEntryList` が生成された後に行われるよう同じコールバック内へ移動しています。